### PR TITLE
fix: SetLogic methods now mirrors Set signature

### DIFF
--- a/src/Set/SetLogic.php
+++ b/src/Set/SetLogic.php
@@ -76,7 +76,9 @@ trait SetLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableSet<mixed>
+	 * @template R
+	 * @param Closure(E, int):R $transform
+	 * @return ImmutableSet<R>
 	 */
 	#[NoDiscard]
 	public function map(Closure $transform): ImmutableSet
@@ -87,7 +89,9 @@ trait SetLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableSet<mixed>
+	 * @template R
+	 * @param Closure(E, int):(R|null) $transform
+	 * @return ImmutableSet<R>
 	 */
 	#[NoDiscard]
 	public function mapNotNull(Closure $transform): ImmutableSet
@@ -98,7 +102,9 @@ trait SetLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableSet<mixed>
+	 * @template R
+	 * @param Closure(E, int):iterable<R> $transform
+	 * @return ImmutableSet<R>
 	 */
 	#[NoDiscard]
 	public function flatMap(Closure $transform): ImmutableSet


### PR DESCRIPTION
Following discussion on #3, some `SetLogic` methods does not mirror `Set` signatures which brings static analysis error when using them: 
- `map`
- `mapNotNull`
- `flapMap`

This PR fixes the 3 method's signatures.

@delacry As a side note: it would be great to have an editorconfig / linting tool like Mago, because I had trouble not breaking the codestyle and keeping the tab indentation 😄 