### PR TITLE
Fix empty mutable factories type inference

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -47,13 +47,13 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * Creates a mutable list.
 	 * If the given data is Closure, the list will be lazily initialized when first accessed.
 	 *
-	 * @template E
-	 * @param iterable<E>|Closure():iterable<E> $data
+	 * @template E = mixed
+	 * @param iterable<E>|Closure():iterable<E>|null $data
 	 * @return MutableList<E>
 	 */
-	function mutableListOf(iterable|Closure $data = []): MutableList
+	function mutableListOf(iterable|Closure|null $data = null): MutableList
 	{
-		return new MutableArrayList($data);
+		return new MutableArrayList($data ?? []);
 	}
 
 	/**
@@ -75,13 +75,13 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * If the given data contains duplicate values, only the first occurrence is kept.
 	 * If the given data is Closure, the set will be lazily initialized when first accessed.
 	 *
-	 * @template E
-	 * @param iterable<E>|Closure():iterable<E> $data
+	 * @template E = mixed
+	 * @param iterable<E>|Closure():iterable<E>|null $data
 	 * @return MutableSet<E>
 	 */
-	function mutableSetOf(iterable|Closure $data = []): MutableSet
+	function mutableSetOf(iterable|Closure|null $data = null): MutableSet
 	{
-		return new MutableHashSet($data);
+		return new MutableHashSet($data ?? []);
 	}
 
 	/**
@@ -116,14 +116,14 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * Creates a mutable map.
 	 * If the given data is Closure, the map will be lazily initialized when first accessed.
 	 *
-	 * @template K of string|int|bool|float|object
-	 * @template V
-	 * @param iterable<K,V>|Closure():iterable<K,V> $data
+	 * @template K of string|int|bool|float|object = string|int|bool|float|object
+	 * @template V = mixed
+	 * @param iterable<K,V>|Closure():iterable<K,V>|null $data
 	 * @return MutableMap<K,V>
 	 */
-	function mutableMapOf(iterable|Closure $data = []): MutableMap
+	function mutableMapOf(iterable|Closure|null $data = null): MutableMap
 	{
-		return MutableHashMap::of($data);
+		return MutableHashMap::of($data ?? []);
 	}
 
 	/**
@@ -159,13 +159,13 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * Int keys are automatically cast to string during construction (handles PHP's numeric string casting).
 	 * If the given data is Closure, the map will be lazily initialized when first accessed.
 	 *
-	 * @template V
-	 * @param iterable<string|int,V>|Closure():iterable<string|int,V> $data
+	 * @template V = mixed
+	 * @param iterable<string|int,V>|Closure():iterable<string|int,V>|null $data
 	 * @return MutableMap<string,V>
 	 */
-	function mutableStringMapOf(iterable|Closure $data = []): MutableMap
+	function mutableStringMapOf(iterable|Closure|null $data = null): MutableMap
 	{
-		return new MutableStringMap($data);
+		return new MutableStringMap($data ?? []);
 	}
 
 	/**
@@ -187,12 +187,12 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * Only accepts int keys; non-int keys throw InvalidKeyTypeException.
 	 * If the given data is Closure, the map will be lazily initialized when first accessed.
 	 *
-	 * @template V
-	 * @param iterable<int,V>|Closure():iterable<int,V> $data
+	 * @template V = mixed
+	 * @param iterable<int,V>|Closure():iterable<int,V>|null $data
 	 * @return MutableMap<int,V>
 	 */
-	function mutableIntMapOf(iterable|Closure $data = []): MutableMap
+	function mutableIntMapOf(iterable|Closure|null $data = null): MutableMap
 	{
-		return new MutableIntMap($data);
+		return new MutableIntMap($data ?? []);
 	}
 }

--- a/tests/Collection/Set/Unit/MutableMapEntrySetTest.php
+++ b/tests/Collection/Set/Unit/MutableMapEntrySetTest.php
@@ -23,7 +23,7 @@ final class MutableMapEntrySetTest extends AbstractSetTestCase
 	 */
 	public function collectionOf(iterable|Closure $data): Set
 	{
-		return mutableMapOf($data)->entries->map(fn ($entry) => $entry->value); // @phpstan-ignore argument.templateType
+		return mutableMapOf($data)->entries->map(fn ($entry) => $entry->value);
 	}
 
 	/**

--- a/tests/Collection/Set/Unit/MutableMapKeySetTest.php
+++ b/tests/Collection/Set/Unit/MutableMapKeySetTest.php
@@ -27,7 +27,7 @@ final class MutableMapKeySetTest extends AbstractSetTestCase
 	 */
 	public function collectionOf(iterable|Closure $data): Set
 	{
-		return mutableMapOf($data)->flip(KeyCollisionStrategy::KeepLast)->keys; // @phpstan-ignore argument.templateType
+		return mutableMapOf($data)->flip(KeyCollisionStrategy::KeepLast)->keys;
 	}
 
 	/**

--- a/tests/Collection/Unit/MutableMapValueCollectionTest.php
+++ b/tests/Collection/Unit/MutableMapValueCollectionTest.php
@@ -23,7 +23,7 @@ final class MutableMapValueCollectionTest extends AbstractCollectionTestCase
 	 */
 	public function collectionOf(iterable|Closure $data): Collection
 	{
-		return mutableMapOf($data)->values; // @phpstan-ignore argument.templateType
+		return mutableMapOf($data)->values;
 	}
 
 	/**


### PR DESCRIPTION
Empty mutableListOf()/mutableSetOf()/mutableMapOf()/… inferred `MutableList<*NEVER*>`, so empty-shell-then-add() was unusable and a var override failed under reportWrongPhpDocTypeInVarTag.

Default the data param to null (not []) and add a template default (@template E = mixed): null no longer binds E=never, so the default fires only for the empty case while typed data still infers precisely. Plain @return is kept so generic forwarding still resolves.

Immutable factories intentionally stay <never> (they widen on add). Also removes 3 now-stale @phpstan-ignore comments.

Closes #4