### PR TITLE
Upgrade PHPStan to ^2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=8.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "2.1.56",
+        "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^13.0",
         "squizlabs/php_codesniffer": "^4.0",
         "slevomat/coding-standard": "^8.16"

--- a/phpstan-tests.neon
+++ b/phpstan-tests.neon
@@ -33,3 +33,16 @@ parameters:
 		-
 			identifier: missingType.generics
 			path: tests/Map/*
+		# PHPUnit assertions that verify runtime behaviour PHPStan 2.2+ treats as
+		# statically certain (via PHPUnit's @phpstan-assert PHPDocs): key-type
+		# enforcement, empty-collection null returns, and trait-context placeholders
+		# read as always-true/false. These live in shared traits analysed in many
+		# concrete contexts; PHPStan matches ignore paths against the *using* test
+		# class, so scope by the directories that use them, mirroring the
+		# method.alreadyNarrowedType entry for tests/Collection above.
+		-
+			identifier: method.alreadyNarrowedType
+			path: tests/Map/*
+		-
+			identifier: method.impossibleType
+			path: tests/Collection/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,42 +17,14 @@ parameters:
 			message: '#MapEntry#'
 			path: src/CollectionLogic.php
 		-
-			identifier: booleanOr.alwaysFalse
-			path: src/CollectionLogic.php
-		-
-			identifier: smallerOrEqual.alwaysFalse
-			path: src/CollectionLogic.php
-		-
 			identifier: missingType.generics
 			path: src/CollectionLogic.php
 		-
 			identifier: deadCode.unreachable
 			path: src/CollectionLogic.php
-		# MapKeySet has E bounded to string|int|bool|float|object, so null/array
-		# checks in CollectionLogic/SetLogic are always-false/always-true in that context.
-		-
-			identifier: identical.alwaysFalse
-			path: src/CollectionLogic.php
-		-
-			identifier: function.impossibleType
-			path: src/CollectionLogic.php
-		# Domain collections that fix the element type to a concrete non-Stringable
-		# class (see tests/Collection/Set/Extending and real user subtypes) make the
-		# Stringable branch of joinToString() provably dead in that context.
-		-
-			identifier: instanceof.alwaysFalse
-			path: src/CollectionLogic.php
-		-
-			identifier: notIdentical.alwaysTrue
-			path: src/Set/SetLogic.php
 		-
 			identifier: return.type
 			path: src/Set/SetLogic.php
-		# Lists fixed to a concrete non-null element type (extension fixtures and real
-		# user subtypes) make the `!== null` guards in ListLogic always-true in context.
-		-
-			identifier: notIdentical.alwaysTrue
-			path: src/List/ListLogic.php
 		# Narrowing sections narrow Collection<E> → ImmutableList<E> / ImmutableSet<E> etc.
 		# in child return types, which PHPStan flags as incompatible.
 		-

--- a/src/CollectionLogic.php
+++ b/src/CollectionLogic.php
@@ -846,7 +846,15 @@ trait CollectionLogic
 		})());
 	}
 
-	/** {@inheritDoc} */
+	/**
+	 * {@inheritDoc}
+	 *
+	 * The params are typed `int` (not the interface's `positive-int`) so the
+	 * defensive non-positive guard below stays a live runtime safety net.
+	 *
+	 * @param int $size
+	 * @param int $step
+	 */
 	#[NoDiscard]
 	public function windowed(int $size, int $step = 1, bool $partialWindows = false): ImmutableList
 	{

--- a/tests/Collection/CollectionAggregate.php
+++ b/tests/Collection/CollectionAggregate.php
@@ -67,12 +67,8 @@ trait CollectionAggregate
 	{
 		$collection = $this->collectionOf([]);
 
-		try {
-			$collection->avg();
-			$this->assertTrue(false, 'Expected UnsupportedOperationException not thrown'); /** @phpstan-ignore-line **/
-		} catch (UnsupportedOperationException) {
-			$this->assertTrue(true); /** @phpstan-ignore-line **/
-		}
+		$this->expectException(UnsupportedOperationException::class);
+		$collection->avg();
 	}
 
 	#[Test]
@@ -129,12 +125,8 @@ trait CollectionAggregate
 	{
 		$collection = $this->collectionOf([]);
 
-		try {
-			$collection->max();
-			$this->assertTrue(false, 'Expected NoSuchElementException not thrown'); /** @phpstan-ignore-line **/
-		} catch (NoSuchElementException) {
-			$this->assertTrue(true); /** @phpstan-ignore-line **/
-		}
+		$this->expectException(NoSuchElementException::class);
+		$collection->max();
 	}
 
 	#[Test]
@@ -199,12 +191,8 @@ trait CollectionAggregate
 	{
 		$collection = $this->collectionOf([]);
 
-		try {
-			$collection->min();
-			$this->assertTrue(false, 'Expected NoSuchElementException not thrown'); /** @phpstan-ignore-line **/
-		} catch (NoSuchElementException) {
-			$this->assertTrue(true); /** @phpstan-ignore-line **/
-		}
+		$this->expectException(NoSuchElementException::class);
+		$collection->min();
 	}
 
 	#[Test]
@@ -372,12 +360,8 @@ trait CollectionAggregate
 	{
 		$collection = $this->collectionOf([]);
 
-		try {
-			$collection->minOf(fn ($element) => $element);
-			$this->assertTrue(false, 'Expected NoSuchElementException not thrown'); /** @phpstan-ignore-line **/
-		} catch (NoSuchElementException) {
-			$this->assertTrue(true); /** @phpstan-ignore-line **/
-		}
+		$this->expectException(NoSuchElementException::class);
+		$collection->minOf(fn ($element) => $element);
 	}
 
 	#[Test]
@@ -421,12 +405,8 @@ trait CollectionAggregate
 	{
 		$collection = $this->collectionOf([]);
 
-		try {
-			$collection->maxOf(fn ($element) => $element);
-			$this->assertTrue(false, 'Expected NoSuchElementException not thrown'); /** @phpstan-ignore-line **/
-		} catch (NoSuchElementException) {
-			$this->assertTrue(true); /** @phpstan-ignore-line **/
-		}
+		$this->expectException(NoSuchElementException::class);
+		$collection->maxOf(fn ($element) => $element);
 	}
 
 	#[Test]


### PR DESCRIPTION
Bump phpstan/phpstan from 2.1.56 to ^2.2 and resolve the errors its stricter PHPDoc-certainty analysis surfaces. No runtime behaviour or public signatures change.

- windowed(): override the inherited positive-int params with @param int on the implementation so its defensive `$size <= 0 || $step <= 0` guard stays a live safety net. The interface keeps positive-int, so callers still get the compile-time contract.
- Convert the try/catch exception assertions in CollectionAggregate to expectException(), matching the rest of the suite.
- Scope the PHPUnit assertion-narrowing checks (method.alreadyNarrowedType, method.impossibleType) to the test directories that trigger them.
- Drop seven ignoreErrors entries 2.2 no longer reports.