### PR TITLE
Type list-returning methods as list<E> instead of array<int, E>

### DIFF
--- a/docs/collection/api/collection.md
+++ b/docs/collection/api/collection.md
@@ -411,7 +411,7 @@ toSet(): ImmutableSet<E>
 Convert to an immutable set (duplicates removed).
 
 ```php
-toArray(): array<int, E>
+toArray(): list<E>
 ```
 Convert to a PHP array.
 

--- a/docs/collection/api/map.md
+++ b/docs/collection/api/map.md
@@ -240,7 +240,7 @@ toArray(KeyCollisionStrategy $onCollision = KeyCollisionStrategy::Throw): array
 Convert to PHP array. Only works with scalar keys. Throws `ConversionException` for object keys or key collisions.
 
 ```php
-toPairs(): array{0:K, 1:V}[]
+toPairs(): list<array{0:K, 1:V}>
 ```
 Convert to array of `[key, value]` pairs.
 

--- a/src/CollectionLogic.php
+++ b/src/CollectionLogic.php
@@ -828,7 +828,7 @@ trait CollectionLogic
 		})());
 	}
 
-	/** @return array<int, E> */
+	/** @return list<E> */
 	public function jsonSerialize(): array
 	{
 		return $this->toArray();

--- a/src/Map/HashMap/HashKeyValueStore.php
+++ b/src/Map/HashMap/HashKeyValueStore.php
@@ -349,7 +349,7 @@ final class HashKeyValueStore implements KeyValueStore
 	}
 
 	/**
-	 * @return array<int,array{0:K,1:V}>
+	 * @return list<array{0:K,1:V}>
 	 */
 	public function toPairs(): array
 	{

--- a/src/Map/IntMap/IntKeyValueStore.php
+++ b/src/Map/IntMap/IntKeyValueStore.php
@@ -334,7 +334,7 @@ final class IntKeyValueStore implements KeyValueStore
 	}
 
 	/**
-	 * @return array<int,array{0:int,1:V}>
+	 * @return list<array{0:int,1:V}>
 	 */
 	public function toPairs(): array
 	{

--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -529,7 +529,7 @@ interface Map extends IteratorAggregate, Countable, ArrayAccess, JsonSerializabl
 	/**
 	 * Converts the map to an array of pairs like [[key1, value1], [key2, value2], ...].
 	 *
-	 * @return array{0:K,1:V}[]
+	 * @return list<array{0:K,1:V}>
 	 */
 	#[NoDiscard]
 	public function toPairs(): array;

--- a/src/Map/StringMap/StringKeyValueStore.php
+++ b/src/Map/StringMap/StringKeyValueStore.php
@@ -326,7 +326,7 @@ final class StringKeyValueStore implements KeyValueStore
 	}
 
 	/**
-	 * @return array<int,array{0:string,1:V}>
+	 * @return list<array{0:string,1:V}>
 	 */
 	public function toPairs(): array
 	{

--- a/src/Operation/ChunkOperation.php
+++ b/src/Operation/ChunkOperation.php
@@ -17,7 +17,7 @@ namespace Noctud\Collection\Operation;
 final class ChunkOperation extends AbstractOperation
 {
 	/**
-	 * @return array<int,array<int,V>>
+	 * @return list<list<V>>
 	 */
 	public function ofSize(int $size): array
 	{

--- a/src/Operation/DropOperation.php
+++ b/src/Operation/DropOperation.php
@@ -35,7 +35,7 @@ final class DropOperation extends AbstractOperation
 
 	/**
 	 * @param int $n
-	 * @return array<int,V>
+	 * @return list<V>
 	 */
 	public function last(int $n): array
 	{
@@ -67,7 +67,7 @@ final class DropOperation extends AbstractOperation
 
 	/**
 	 * @param callable(V, int):bool $predicate
-	 * @return array<int,V>
+	 * @return list<V>
 	 */
 	public function lastByPredicate(callable $predicate): array
 	{

--- a/src/Operation/PartitionOperation.php
+++ b/src/Operation/PartitionOperation.php
@@ -18,7 +18,7 @@ final class PartitionOperation extends AbstractOperation
 {
 	/**
 	 * @param callable(V, int):bool $predicate
-	 * @return array{array<int,V>, array<int,V>}
+	 * @return array{list<V>, list<V>}
 	 */
 	public function byPredicate(callable $predicate): array
 	{

--- a/src/Operation/TakeOperation.php
+++ b/src/Operation/TakeOperation.php
@@ -39,7 +39,7 @@ final class TakeOperation extends AbstractOperation
 
 	/**
 	 * @param int $n
-	 * @return array<int,V>
+	 * @return list<V>
 	 */
 	public function last(int $n): array
 	{
@@ -68,7 +68,7 @@ final class TakeOperation extends AbstractOperation
 
 	/**
 	 * @param callable(V, int):bool $predicate
-	 * @return array<int,V>
+	 * @return list<V>
 	 */
 	public function lastByPredicate(callable $predicate): array
 	{

--- a/src/Store/KeyValueStore.php
+++ b/src/Store/KeyValueStore.php
@@ -203,7 +203,7 @@ interface KeyValueStore extends IteratorAggregate
 	/**
 	 * Returns all entries as an array of [key, value] pairs.
 	 *
-	 * @return array<int,array{0:K,1:V}>
+	 * @return list<array{0:K,1:V}>
 	 */
 	public function toPairs(): array;
 


### PR DESCRIPTION
Follow-up to #13: type the remaining genuinely-list-returning methods as list<…> instead of array<int,…> - Collection::jsonSerialize (delegates to toArray), the toPairs chain (Map + KeyValueStore interfaces and the Hash/String/Int stores), and the internal Take/Drop/Chunk/Partition operations - and sync the toArray/toPairs API docs to match; PHPDoc-only.