### PR TITLE
Narrow key type for `Map::toArray()`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,11 @@
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/</directory>
+            <!--
+                tests/Type holds PHPStan assertType() type-inference tests, checked by
+                `phpstan analyse` (via phpstan-tests.neon), not by PHPUnit.
+            -->
+            <exclude>./tests/Type</exclude>
         </testsuite>
     </testsuites>
     <source>

--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -489,7 +489,7 @@ interface Map extends IteratorAggregate, Countable, ArrayAccess, JsonSerializabl
 	 * - Objects are not supported
 	 *
 	 * @param KeyCollisionStrategy $onCollision Strategy for handling key collisions during conversion.
-	 * @return array<array-key,V>
+	 * @return (K is array-key ? array<K,V> : array<array-key,V>)
 	 * @throws ConversionException
 	 */
 	#[NoDiscard]

--- a/src/Map/MapLogic.php
+++ b/src/Map/MapLogic.php
@@ -667,7 +667,10 @@ trait MapLogic
 
 	// --- Conversion ---
 
-	/** {@inheritDoc} */
+	/**
+	 * {@inheritDoc}
+	 * @return array<array-key,V>
+	 */
 	#[NoDiscard]
 	public function toArray(KeyCollisionStrategy $onCollision = KeyCollisionStrategy::Throw): array
 	{

--- a/tests/Type/MapToArrayTypeTest.php
+++ b/tests/Type/MapToArrayTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Type;
+
+use stdClass;
+use function Noctud\Collection\listOf;
+use function PHPStan\Testing\assertType;
+
+assertType(
+	'array<string, string>',
+	listOf(['a', 'b', 'c'])->toMap(fn (string $i) => $i)->toArray(),
+);
+assertType(
+	'array<int, string>',
+	listOf(['a', 'b'])->toMap(fn (string $i): int => 0)->toArray(),
+);
+
+assertType(
+	'array<int, int>',
+	listOf(['a', 'b'])->toMap(fn (string $i): int => 0, fn (string $i): int => 1)->toArray(),
+);
+
+assertType(
+	'array<string>',
+	listOf(['a'])->toMap(fn (string $i) => new stdClass())->toArray(),
+);


### PR DESCRIPTION
Hi!

currently `Map::toArray()` always return `array<array-key, V>`, so even if the type of the key is known, this type is lost when the Map is transformed into an array.

Thus, simple things like this would be infered as `array<string>`, although it is `array<string, string>`:
```php
listOf(['a', 'b', 'c'])->toMap(fn(string $i) => $i)->toArray();
```

I think this would deserve some PHPStan testing, using `PHPStan\Testing\assertType()` but I've not found any test of this kind in the lib, so I haven't added any test. Let me know if you think I should introduce some tests like this (for example, we have [a bunch of them in Foundry](https://github.com/zenstruck/foundry/blob/d9ed62b221add0287388b17a252cb6c072e834a7/stubs/phpstan/functions.php#L4) in order to prevent static analysis regressions)