### PR TITLE
[PHPStan] narrow `sum()` return type

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -226,7 +226,9 @@ interface Collection extends IteratorAggregate, Countable, JsonSerializable
 	/**
 	 * Returns the sum of all elements or values returned by the selector.
 	 *
-	 * @param Closure(E, int):(int|float)|null $selector
+	 * @template TSum
+	 * @param (Closure(E, int):TSum)|null $selector
+	 * @return ($selector is null ? (E is int ? int : int|float) : (TSum is int ? int : int|float))
 	 */
 	public function sum(?Closure $selector = null): int|float;
 

--- a/src/CollectionLogic.php
+++ b/src/CollectionLogic.php
@@ -305,6 +305,7 @@ trait CollectionLogic
 	}
 
 	/** {@inheritDoc} */
+	// @phpstan-ignore conditionalType.subjectNotFound (E is concrete, not a template, in extending fixtures)
 	public function sum(?Closure $selector = null): int|float
 	{
 		$sum = 0;

--- a/tests/Type/CollectionSumTypeTest.php
+++ b/tests/Type/CollectionSumTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Type;
+
+use function Noctud\Collection\listOf;
+use function PHPStan\Testing\assertType;
+
+// A collection of ints sums to an int.
+assertType('int', listOf([1, 2, 3])->sum());
+
+// As soon as a float is involved, the sum widens back to int|float.
+assertType('float|int', listOf([1.0, 2.0])->sum());
+assertType('float|int', listOf([1, 2.0])->sum());
+
+// With a selector declared to return int, the sum narrows to int.
+assertType('int', listOf([1, 2, 3])->sum(fn (int $x): int => $x * 2));
+// Any other selector return type (float, or an un-inferrable/mixed one) stays int|float.
+assertType('float|int', listOf([1, 2, 3])->sum(fn (int $x): float => $x / 2));


### PR DESCRIPTION
`sum()` return type should be narrowed to `int` if the collection's type is `int`