### PR TITLE
fix: narrow `filterNotNull()` and `filterValuesNotNull()` return types

### DIFF
--- a/bin/NarrowingGenerator.php
+++ b/bin/NarrowingGenerator.php
@@ -202,6 +202,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': Set',
 			'Collection<E>' => 'Set<E>',
+			'Collection<(E is null ? never : E)>' => 'Set<(E is null ? never : E)>',
 			'Collection<R>' => 'Set<R>',
 			'Collection<mixed>' => 'Set<mixed>',
 			'Collection<T>' => 'Set<T>',
@@ -231,6 +232,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($immutableCollectionContent, 'ImmutableCollection', [
 			': ImmutableCollection' => ': ImmutableSet',
 			'ImmutableCollection<E>' => 'ImmutableSet<E>',
+			'ImmutableCollection<(E is null ? never : E)>' => 'ImmutableSet<(E is null ? never : E)>',
 			'ImmutableCollection<E|NE>' => 'ImmutableSet<E|NE>',
 			'ImmutableCollection<R>' => 'ImmutableSet<R>',
 			'ImmutableCollection<mixed>' => 'ImmutableSet<mixed>',
@@ -285,6 +287,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': ListInterface',
 			'Collection<E>' => 'ListInterface<E>',
+			'Collection<(E is null ? never : E)>' => 'ListInterface<(E is null ? never : E)>',
 			'Collection<R>' => 'ListInterface<R>',
 			'Collection<mixed>' => 'ListInterface<mixed>',
 			'Collection<T>' => 'ListInterface<T>',
@@ -314,6 +317,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': ImmutableCollection',
 			'Collection<E>' => 'ImmutableCollection<E>',
+			'Collection<(E is null ? never : E)>' => 'ImmutableCollection<(E is null ? never : E)>',
 			'Collection<R>' => 'ImmutableCollection<R>',
 			'Collection<mixed>' => 'ImmutableCollection<mixed>',
 			'Collection<T>' => 'ImmutableCollection<T>',
@@ -340,6 +344,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': ImmutableCollection',
 			'Collection<E>' => 'ImmutableCollection<E>',
+			'Collection<(E is null ? never : E)>' => 'ImmutableCollection<(E is null ? never : E)>',
 			'Collection<R>' => 'ImmutableCollection<R>',
 			'Collection<mixed>' => 'ImmutableCollection<mixed>',
 			'Collection<T>' => 'ImmutableCollection<T>',
@@ -366,6 +371,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': ImmutableList',
 			'Collection<E>' => 'ImmutableList<E>',
+			'Collection<(E is null ? never : E)>' => 'ImmutableList<(E is null ? never : E)>',
 			'Collection<R>' => 'ImmutableList<R>',
 			'Collection<mixed>' => 'ImmutableList<mixed>',
 			'Collection<T>' => 'ImmutableList<T>',
@@ -392,6 +398,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($collectionContent, 'Collection', [
 			': Collection' => ': ImmutableSet',
 			'Collection<E>' => 'ImmutableSet<E>',
+			'Collection<(E is null ? never : E)>' => 'ImmutableSet<(E is null ? never : E)>',
 			'Collection<R>' => 'ImmutableSet<R>',
 			'Collection<mixed>' => 'ImmutableSet<mixed>',
 			'Collection<T>' => 'ImmutableSet<T>',
@@ -419,6 +426,7 @@ final class NarrowingGenerator
 			': Map' => ': ImmutableMap',
 			'Map<K,V>' => 'ImmutableMap<K,V>',
 			'Map<K, V>' => 'ImmutableMap<K, V>',
+			'Map<K, (V is null ? never : V)>' => 'ImmutableMap<K, (V is null ? never : V)>',
 			'Map<NK,V>' => 'ImmutableMap<NK,V>',
 			'Map<NK, V>' => 'ImmutableMap<NK, V>',
 			'Map<K,NV>' => 'ImmutableMap<K,NV>',
@@ -441,6 +449,7 @@ final class NarrowingGenerator
 		return self::generateNarrowing($immutableCollectionContent, 'ImmutableCollection', [
 			': ImmutableCollection' => ': ImmutableList',
 			'ImmutableCollection<E>' => 'ImmutableList<E>',
+			'ImmutableCollection<(E is null ? never : E)>' => 'ImmutableList<(E is null ? never : E)>',
 			'ImmutableCollection<E|NE>' => 'ImmutableList<E|NE>',
 			'ImmutableCollection<R>' => 'ImmutableList<R>',
 			'ImmutableCollection<mixed>' => 'ImmutableList<mixed>',
@@ -544,6 +553,7 @@ final class NarrowingGenerator
 			': Map' => ': ImmutableMap',
 			'Map<K,V>' => 'ImmutableMap<K,V>',
 			'Map<K, V>' => 'ImmutableMap<K, V>',
+			'Map<K, (V is null ? never : V)>' => 'ImmutableMap<K, (V is null ? never : V)>',
 			'Map<NK,V>' => 'ImmutableMap<NK,V>',
 			'Map<NK, V>' => 'ImmutableMap<NK, V>',
 			'Map<K,NV>' => 'ImmutableMap<K,NV>',

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -360,7 +360,7 @@ interface Collection extends IteratorAggregate, Countable, JsonSerializable
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return Collection<E>
+	 * @return Collection<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): Collection;

--- a/src/ImmutableCollection.php
+++ b/src/ImmutableCollection.php
@@ -143,7 +143,7 @@ interface ImmutableCollection extends Collection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableCollection<E>
+	 * @return ImmutableCollection<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableCollection;

--- a/src/List/ImmutableList.php
+++ b/src/List/ImmutableList.php
@@ -203,7 +203,7 @@ interface ImmutableList extends ListInterface, ImmutableCollection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableList<E>
+	 * @return ImmutableList<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableList;

--- a/src/List/ListInterface.php
+++ b/src/List/ListInterface.php
@@ -121,7 +121,7 @@ interface ListInterface extends Collection, ArrayAccess
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ListInterface<E>
+	 * @return ListInterface<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ListInterface;

--- a/src/List/ListLogic.php
+++ b/src/List/ListLogic.php
@@ -179,9 +179,9 @@ trait ListLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableList<E>
+	 * @return ImmutableList<(E is null ? never : E)>
 	 */
-	#[NoDiscard]
+	#[NoDiscard] // @phpstan-ignore conditionalType.subjectNotFound (in classes with a concrete E the conditional subject is already substituted)
 	public function filterNotNull(): ImmutableList
 	{
 		return $this->newCollectionOf(new FilterOperation($this->store)->byValue(fn ($v) => $v !== null));

--- a/src/List/WritableList.php
+++ b/src/List/WritableList.php
@@ -178,7 +178,7 @@ interface WritableList extends ListInterface, WritableCollection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableList<E>
+	 * @return ImmutableList<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableList;

--- a/src/Map/ImmutableMap.php
+++ b/src/Map/ImmutableMap.php
@@ -235,7 +235,7 @@ interface ImmutableMap extends Map
 	/**
 	 * Creates a new map excluding entries with null values.
 	 *
-	 * @return ImmutableMap<K,V> New map without null values.
+	 * @return ImmutableMap<K, (V is null ? never : V)> New map without null values.
 	 */
 	#[NoDiscard]
 	public function filterValuesNotNull(): ImmutableMap;

--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -198,7 +198,7 @@ interface Map extends IteratorAggregate, Countable, ArrayAccess, JsonSerializabl
 	/**
 	 * Creates a new map excluding entries with null values.
 	 *
-	 * @return Map<K,V> New map without null values.
+	 * @return Map<K, (V is null ? never : V)> New map without null values.
 	 */
 	#[NoDiscard]
 	public function filterValuesNotNull(): Map;

--- a/src/Map/MapLogic.php
+++ b/src/Map/MapLogic.php
@@ -223,9 +223,9 @@ trait MapLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableMap<K,V>
+	 * @return ImmutableMap<K, (V is null ? never : V)>
 	 */
-	#[NoDiscard]
+	#[NoDiscard] // @phpstan-ignore conditionalType.subjectNotFound (in classes with a concrete V the conditional subject is already substituted)
 	public function filterValuesNotNull(): ImmutableMap
 	{
 		return $this->newMapOf(

--- a/src/Map/WritableMap.php
+++ b/src/Map/WritableMap.php
@@ -234,7 +234,7 @@ interface WritableMap extends Map
 	/**
 	 * Creates a new map excluding entries with null values.
 	 *
-	 * @return ImmutableMap<K,V> New map without null values.
+	 * @return ImmutableMap<K, (V is null ? never : V)> New map without null values.
 	 */
 	#[NoDiscard]
 	public function filterValuesNotNull(): ImmutableMap;

--- a/src/Set/ImmutableSet.php
+++ b/src/Set/ImmutableSet.php
@@ -153,7 +153,7 @@ interface ImmutableSet extends Set, ImmutableCollection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableSet<E>
+	 * @return ImmutableSet<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableSet;

--- a/src/Set/Set.php
+++ b/src/Set/Set.php
@@ -37,7 +37,7 @@ interface Set extends Collection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return Set<E>
+	 * @return Set<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): Set;

--- a/src/Set/SetLogic.php
+++ b/src/Set/SetLogic.php
@@ -58,9 +58,9 @@ trait SetLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @return ImmutableSet<E>
+	 * @return ImmutableSet<(E is null ? never : E)>
 	 */
-	#[NoDiscard]
+	#[NoDiscard] // @phpstan-ignore conditionalType.subjectNotFound, conditionalType.alwaysFalse (in classes with a concrete or non-nullable E the conditional is already decided)
 	public function filterNotNull(): ImmutableSet
 	{
 		return $this->newCollectionOf(new FilterOperation($this->store)->byValue(fn ($v) => $v !== null));

--- a/src/Set/WritableSet.php
+++ b/src/Set/WritableSet.php
@@ -136,7 +136,7 @@ interface WritableSet extends Set, WritableCollection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableSet<E>
+	 * @return ImmutableSet<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableSet;

--- a/src/WritableCollection.php
+++ b/src/WritableCollection.php
@@ -136,7 +136,7 @@ interface WritableCollection extends Collection
 	/**
 	 * Filter non-null elements.
 	 *
-	 * @return ImmutableCollection<E>
+	 * @return ImmutableCollection<(E is null ? never : E)>
 	 */
 	#[NoDiscard]
 	public function filterNotNull(): ImmutableCollection;

--- a/tests/Type/FilterNotNullTypeTest.php
+++ b/tests/Type/FilterNotNullTypeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Type;
+
+use Noctud\Collection\Collection;
+
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\mutableListOf;
+use function Noctud\Collection\mutableSetOf;
+use function Noctud\Collection\mutableStringMapOf;
+use function Noctud\Collection\setOf;
+use function Noctud\Collection\stringMapOf;
+use function PHPStan\Testing\assertType;
+
+// filterNotNull() removes null from the element type (issue #16).
+assertType('Noctud\Collection\List\ImmutableList<int>', listOf([1, null])->filterNotNull());
+assertType('Noctud\Collection\List\ImmutableList<int>', mutableListOf([1, null])->filterNotNull());
+assertType('Noctud\Collection\Set\ImmutableSet<int>', setOf([1, null])->filterNotNull());
+assertType('Noctud\Collection\Set\ImmutableSet<int>', mutableSetOf([1, null])->filterNotNull());
+
+// Also through the base Collection interface.
+/** @var Collection<string|null> $c */
+$c = listOf(['a', null]);
+assertType('Noctud\Collection\Collection<string>', $c->filterNotNull());
+
+// A collection without null keeps its element type unchanged.
+assertType('Noctud\Collection\List\ImmutableList<int>', listOf([1, 2])->filterNotNull());
+
+// filterValuesNotNull() removes null from the value type, keys are preserved.
+assertType('Noctud\Collection\Map\ImmutableMap<string, int>', stringMapOf(['a' => 1, 'b' => null])->filterValuesNotNull());
+assertType('Noctud\Collection\Map\ImmutableMap<string, int>', mutableStringMapOf(['a' => 1, 'b' => null])->filterValuesNotNull());


### PR DESCRIPTION
Hi! I just gave a try to the solution you suggested to remove `null` from the type

fixes #16
