### PR TITLE
feat: introduce Sequence type

### DIFF
--- a/src/Exception/InvalidSequenceSourceException.php
+++ b/src/Exception/InvalidSequenceSourceException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Exception;
+
+use LogicException;
+
+/**
+ * Thrown when a sequence source closure returns a non-iterable value.
+ */
+final class InvalidSequenceSourceException extends LogicException
+{
+	public static function closureReturnedNonIterable(mixed $produced): self
+	{
+		return new self(
+			sprintf('The sequence\'s source closure must return an iterable, got %s.', get_debug_type($produced)),
+		);
+	}
+}

--- a/src/Exception/SequenceAlreadyIteratedException.php
+++ b/src/Exception/SequenceAlreadyIteratedException.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Exception;
+
+/**
+ * Thrown when a sequence backed by a non-replayable source is iterated a second time,
+ * or when a sequence source closure returns the same iterator instance twice.
+ */
+final class SequenceAlreadyIteratedException extends UnsupportedOperationException
+{
+	public static function nonReplayableSourceAlreadyIterated(): self
+	{
+		return new self(
+			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
+		);
+	}
+
+	public static function sourceClosureReturnedSameIterator(): self
+	{
+		return new self(
+			'The sequence\'s source closure returned the same iterator instance again - it must produce a fresh iterable on each call.',
+		);
+	}
+}

--- a/src/Exception/SequenceAlreadyIteratedException.php
+++ b/src/Exception/SequenceAlreadyIteratedException.php
@@ -11,7 +11,8 @@ namespace Noctud\Collection\Exception;
 
 /**
  * Thrown when a sequence backed by a non-replayable source is iterated a second time,
- * or when a sequence source closure returns the same iterator instance twice.
+ * or when a sequence source - a closure or an IteratorAggregate - hands back the same
+ * iterator instance twice.
  */
 final class SequenceAlreadyIteratedException extends UnsupportedOperationException
 {
@@ -22,10 +23,10 @@ final class SequenceAlreadyIteratedException extends UnsupportedOperationExcepti
 		);
 	}
 
-	public static function sourceClosureReturnedSameIterator(): self
+	public static function sourceReturnedSameIterator(): self
 	{
 		return new self(
-			'The sequence\'s source closure returned the same iterator instance again - it must produce a fresh iterable on each call.',
+			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 	}
 }

--- a/src/Sequence/GeneratorSequence.php
+++ b/src/Sequence/GeneratorSequence.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Sequence;
+
+use Closure;
+
+/**
+ * Lazy sequence iterating through generators, whatever the source kind.
+ * If the given source is a Closure, it is a producer: invoked once per pass and expected
+ * to return a fresh iterable on each call.
+ *
+ * The class is final; if you want your own Sequence, use the SequenceLogic trait in your
+ * own class; this way you are not tied to our class hierarchy (you can extend your own
+ * base class).
+ *
+ * @template E
+ * @implements Sequence<E>
+ */
+final class GeneratorSequence implements Sequence
+{
+	/** @use SequenceLogic<E> */
+	use SequenceLogic;
+
+	/**
+	 * @param iterable<E>|Closure():iterable<E> $source
+	 */
+	public function __construct(iterable|Closure $source = [])
+	{
+		$this->source = $source;
+	}
+}

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -22,13 +22,13 @@ use NoDiscard;
  * terminal operation). A sequence guarantees at least one pass; whether it can be
  * iterated again depends on its source:
  *
- * - an array or an IteratorAggregate (e.g. a Collection): the sequence replays,
- *   pulling fresh elements every pass;
- * - a Closure: a producer, re-invoked on every pass. Whatever the closure does to
- *   build its iterable runs again each time - if it fires a SQL query, that query is
- *   re-executed on every iteration of the sequence. It must return a fresh iterable
- *   on each call; returning the same iterator instance again throws
- *   SequenceAlreadyIteratedException;
+ * - an array: the sequence replays, pulling fresh elements every pass;
+ * - a Closure or an IteratorAggregate (e.g. a Collection): a producer, asked for an
+ *   iterable on every pass. Whatever it does to build that iterable runs again each
+ *   time - if it fires a SQL query, that query is re-executed on every iteration of
+ *   the sequence. It must hand back a fresh iterator on each call; handing back the
+ *   iterator of the previous pass (a getIterator() returning a Generator it keeps
+ *   around, for instance) throws SequenceAlreadyIteratedException;
  * - a raw Iterator/Generator: the sequence is single-pass and any further iteration
  *   throws SequenceAlreadyIteratedException (a partial pass counts as consumed).
  *

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Sequence;
+
+use Closure;
+use IteratorAggregate;
+use Noctud\Collection\List\ImmutableList;
+use Noctud\Collection\Set\ImmutableSet;
+use NoDiscard;
+
+/**
+ * Lazily evaluated stream of values.
+ *
+ * Nothing is pulled from the source before the sequence is iterated (a foreach or a
+ * terminal operation). A sequence guarantees at least one pass; whether it can be
+ * iterated again depends on its source:
+ *
+ * - an array or an IteratorAggregate (e.g. a Collection): the sequence replays,
+ *   pulling fresh elements every pass;
+ * - a Closure: a producer, re-invoked on every pass. Whatever the closure does to
+ *   build its iterable runs again each time - if it fires a SQL query, that query is
+ *   re-executed on every iteration of the sequence. It must return a fresh iterable
+ *   on each call; returning the same iterator instance again throws
+ *   SequenceAlreadyIteratedException;
+ * - a raw Iterator/Generator: the sequence is single-pass and any further iteration
+ *   throws SequenceAlreadyIteratedException (a partial pass counts as consumed).
+ *
+ * Keys are positional: every pass yields fresh 0..n keys, whatever the source yields.
+ *
+ * Deliberately neither Countable (counting would silently consume a pass; native
+ * count($seq) is a TypeError by design) nor JsonSerializable
+ * (json_encode would be a hidden materialization) - materialize explicitly with
+ * toList() or toArray() instead.
+ *
+ * @template E
+ * @extends IteratorAggregate<int, E>
+ */
+interface Sequence extends IteratorAggregate
+{
+	// --- Transformation ---
+
+	/**
+	 * Filter elements by predicate.
+	 *
+	 * @param Closure(E, int):bool $predicate
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function filter(Closure $predicate): Sequence;
+
+	/**
+	 * Map elements to a new sequence.
+	 * The transform receives the element and optionally the index.
+	 *
+	 * @template R
+	 * @param Closure(E, int):R $transform
+	 * @return Sequence<R>
+	 */
+	#[NoDiscard]
+	public function map(Closure $transform): Sequence;
+
+	// --- Conversion ---
+
+	/**
+	 * Convert to an immutable list, consuming one pass of the sequence.
+	 *
+	 * @return ImmutableList<E>
+	 */
+	#[NoDiscard]
+	public function toList(): ImmutableList;
+
+	/**
+	 * Convert to an immutable set (duplicates removed), consuming one pass of the sequence.
+	 *
+	 * @return ImmutableSet<E>
+	 */
+	#[NoDiscard]
+	public function toSet(): ImmutableSet;
+
+	/**
+	 * Convert to a primitive PHP array, consuming one pass of the sequence.
+	 *
+	 * @return list<E>
+	 */
+	#[NoDiscard]
+	public function toArray(): array;
+}

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Sequence;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Noctud\Collection\Exception\InvalidSequenceSourceException;
+use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\List\ImmutableList;
+use Noctud\Collection\Operation\FilterOperation;
+use Noctud\Collection\Operation\MapKeyValueOperation;
+use Noctud\Collection\Set\ImmutableSet;
+use Traversable;
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\setOf;
+
+/**
+ * @template E
+ * @mixin Sequence<E>
+ */
+trait SequenceLogic
+{
+	/** @var iterable<E>|Closure():iterable<E> */
+	private iterable|Closure $source;
+
+	/** Whether a single-pass source has already been handed out. */
+	private bool $consumed = false;
+
+	/**
+	 * Iterator returned by the source closure on the previous pass. The reference is kept
+	 * (instead of spl_object_id, whose values can be reused after garbage collection) so
+	 * the identity guard in resolveSourceForThisPass() is collision-free.
+	 */
+	private ?Traversable $lastProduced = null;
+
+	/**
+	 * @return Generator<int, E>
+	 */
+	public function getIterator(): Generator
+	{
+		$iterable = $this->resolveSourceForThisPass();
+
+		return (static function () use ($iterable): Generator {
+			$i = 0;
+			foreach ($iterable as $value) {
+				yield $i++ => $value;
+			}
+		})();
+	}
+
+	/** {@inheritDoc} */
+	public function filter(Closure $predicate): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new FilterOperation($this)->byPredicate($predicate));
+	}
+
+	/** {@inheritDoc} */
+	public function map(Closure $transform): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new MapKeyValueOperation($this)->items($transform));
+	}
+
+	/** {@inheritDoc} */
+	public function toList(): ImmutableList
+	{
+		return listOf($this);
+	}
+
+	/** {@inheritDoc} */
+	public function toSet(): ImmutableSet
+	{
+		return setOf($this);
+	}
+
+	/** {@inheritDoc} */
+	public function toArray(): array
+	{
+		return iterator_to_array($this, false);
+	}
+
+	/**
+	 * Resolves the source for one pass, enforcing the replayability contract: arrays and
+	 * IteratorAggregate sources replay freely, a Closure is a producer invoked once per
+	 * pass (and must return a fresh iterable each time), and any other Traversable is
+	 * single-pass - even when technically rewindable, matching Kotlin's Iterator.asSequence().
+	 * The guard runs here, at getIterator() call time, so a violation throws at the start
+	 * of the offending pass instead of silently yielding nothing.
+	 *
+	 * @return iterable<E>
+	 */
+	private function resolveSourceForThisPass(): iterable
+	{
+		$source = $this->source;
+
+		if ($source instanceof Closure) {
+			$produced = $source();
+
+			// @phpstan-ignore function.alreadyNarrowedType (the closure's return type is a PHPDoc promise PHP cannot enforce)
+			if (!is_iterable($produced)) {
+				throw InvalidSequenceSourceException::closureReturnedNonIterable($produced);
+			}
+
+			if ($produced instanceof Traversable) {
+				if ($produced === $this->lastProduced) {
+					throw SequenceAlreadyIteratedException::sourceClosureReturnedSameIterator();
+				}
+
+				$this->lastProduced = $produced;
+			}
+
+			return $produced;
+		}
+
+		if (is_array($source) || $source instanceof IteratorAggregate) {
+			return $source;
+		}
+
+		if ($this->consumed) {
+			throw SequenceAlreadyIteratedException::nonReplayableSourceAlreadyIterated();
+		}
+
+		$this->consumed = true;
+
+		return $source;
+	}
+
+	/**
+	 * Chains a lazy stage. The factory is invoked once per pass (never at chain-build
+	 * time), so every pass runs a fresh Operation generator and replayability follows
+	 * the root source.
+	 *
+	 * @template R
+	 * @param Closure():iterable<R> $factory
+	 * @return Sequence<R>
+	 */
+	private function newSequenceOf(Closure $factory): Sequence
+	{
+		return new GeneratorSequence($factory);
+	}
+}

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -20,6 +20,7 @@ use Noctud\Collection\Operation\MapKeyValueOperation;
 use Noctud\Collection\Set\ImmutableSet;
 use NoDiscard;
 use Traversable;
+use WeakReference;
 use function Noctud\Collection\listOf;
 use function Noctud\Collection\setOf;
 
@@ -36,11 +37,14 @@ trait SequenceLogic
 	private bool $consumed = false;
 
 	/**
-	 * Iterator the source produced on the previous pass. The reference is kept (instead of
-	 * spl_object_id, whose values can be reused after garbage collection) so the identity
-	 * guard in resolveProducedIterable() is collision-free.
+	 * Iterator the source produced on the previous pass, compared by identity in
+	 * resolveProducedIterable(). Held weakly so a consumed iterator - and the file handle or
+	 * cursor behind it - is freed as soon as nothing else uses it: a collected one leaves
+	 * get() returning null, and an iterator nobody holds cannot be handed back to us.
+	 *
+	 * @var WeakReference<Traversable>|null
 	 */
-	private ?Traversable $lastProduced = null;
+	private ?WeakReference $lastProduced = null;
 
 	/**
 	 * @return Generator<int, E>
@@ -93,6 +97,20 @@ trait SequenceLogic
 	}
 
 	/**
+	 * Chains a lazy stage. The factory is invoked once per pass (never at chain-build
+	 * time), so every pass runs a fresh Operation generator and replayability follows
+	 * the root source.
+	 *
+	 * @template R
+	 * @param Closure():iterable<R> $factory
+	 * @return Sequence<R>
+	 */
+	protected function newSequenceOf(Closure $factory): Sequence
+	{
+		return new GeneratorSequence($factory);
+	}
+
+	/**
 	 * Resolves the source for one pass, enforcing the replayability contract: an array
 	 * replays freely, a Closure and an IteratorAggregate are both producers asked for an
 	 * iterable once per pass (and must hand back a fresh one each time), and any other
@@ -123,7 +141,7 @@ trait SequenceLogic
 		}
 
 		if ($source instanceof IteratorAggregate) {
-			return $this->resolveProducedIterable($source->getIterator());
+			return $this->resolveProducedIterable($source);
 		}
 
 		if ($this->consumed) {
@@ -146,28 +164,20 @@ trait SequenceLogic
 	 */
 	private function resolveProducedIterable(iterable $produced): iterable
 	{
+		if ($produced instanceof IteratorAggregate) {
+			$produced = $produced->getIterator();
+		}
+
+		// Cursors only: an array is a value, always replayable, and a nested aggregate is itself
+		// a producer, re-invoked per pass by the foreach that unwraps it.
 		if ($produced instanceof Traversable && !$produced instanceof IteratorAggregate) {
-			if ($produced === $this->lastProduced) {
+			if ($this->lastProduced?->get() === $produced) {
 				throw SequenceAlreadyIteratedException::sourceReturnedSameIterator();
 			}
 
-			$this->lastProduced = $produced;
+			$this->lastProduced = WeakReference::create($produced);
 		}
 
 		return $produced;
-	}
-
-	/**
-	 * Chains a lazy stage. The factory is invoked once per pass (never at chain-build
-	 * time), so every pass runs a fresh Operation generator and replayability follows
-	 * the root source.
-	 *
-	 * @template R
-	 * @param Closure():iterable<R> $factory
-	 * @return Sequence<R>
-	 */
-	private function newSequenceOf(Closure $factory): Sequence
-	{
-		return new GeneratorSequence($factory);
 	}
 }

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -18,6 +18,7 @@ use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Operation\FilterOperation;
 use Noctud\Collection\Operation\MapKeyValueOperation;
 use Noctud\Collection\Set\ImmutableSet;
+use NoDiscard;
 use Traversable;
 use function Noctud\Collection\listOf;
 use function Noctud\Collection\setOf;
@@ -57,30 +58,35 @@ trait SequenceLogic
 	}
 
 	/** {@inheritDoc} */
+	#[NoDiscard]
 	public function filter(Closure $predicate): Sequence
 	{
 		return $this->newSequenceOf(fn (): iterable => new FilterOperation($this)->byPredicate($predicate));
 	}
 
 	/** {@inheritDoc} */
+	#[NoDiscard]
 	public function map(Closure $transform): Sequence
 	{
 		return $this->newSequenceOf(fn (): iterable => new MapKeyValueOperation($this)->items($transform));
 	}
 
 	/** {@inheritDoc} */
+	#[NoDiscard]
 	public function toList(): ImmutableList
 	{
 		return listOf($this);
 	}
 
 	/** {@inheritDoc} */
+	#[NoDiscard]
 	public function toSet(): ImmutableSet
 	{
 		return setOf($this);
 	}
 
 	/** {@inheritDoc} */
+	#[NoDiscard]
 	public function toArray(): array
 	{
 		return iterator_to_array($this, false);

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -35,9 +35,9 @@ trait SequenceLogic
 	private bool $consumed = false;
 
 	/**
-	 * Iterator returned by the source closure on the previous pass. The reference is kept
-	 * (instead of spl_object_id, whose values can be reused after garbage collection) so
-	 * the identity guard in resolveSourceForThisPass() is collision-free.
+	 * Iterator the source produced on the previous pass. The reference is kept (instead of
+	 * spl_object_id, whose values can be reused after garbage collection) so the identity
+	 * guard in resolveProducedIterable() is collision-free.
 	 */
 	private ?Traversable $lastProduced = null;
 
@@ -87,12 +87,13 @@ trait SequenceLogic
 	}
 
 	/**
-	 * Resolves the source for one pass, enforcing the replayability contract: arrays and
-	 * IteratorAggregate sources replay freely, a Closure is a producer invoked once per
-	 * pass (and must return a fresh iterable each time), and any other Traversable is
-	 * single-pass - even when technically rewindable, matching Kotlin's Iterator.asSequence().
-	 * The guard runs here, at getIterator() call time, so a violation throws at the start
-	 * of the offending pass instead of silently yielding nothing.
+	 * Resolves the source for one pass, enforcing the replayability contract: an array
+	 * replays freely, a Closure and an IteratorAggregate are both producers asked for an
+	 * iterable once per pass (and must hand back a fresh one each time), and any other
+	 * Traversable is single-pass - even when technically rewindable, matching Kotlin's
+	 * Iterator.asSequence(). The guard runs here, at getIterator() call time, so a
+	 * violation throws at the start of the offending pass instead of silently yielding
+	 * nothing.
 	 *
 	 * @return iterable<E>
 	 */
@@ -108,19 +109,15 @@ trait SequenceLogic
 				throw InvalidSequenceSourceException::closureReturnedNonIterable($produced);
 			}
 
-			if ($produced instanceof Traversable) {
-				if ($produced === $this->lastProduced) {
-					throw SequenceAlreadyIteratedException::sourceClosureReturnedSameIterator();
-				}
-
-				$this->lastProduced = $produced;
-			}
-
-			return $produced;
+			return $this->resolveProducedIterable($produced);
 		}
 
-		if (is_array($source) || $source instanceof IteratorAggregate) {
+		if (is_array($source)) {
 			return $source;
+		}
+
+		if ($source instanceof IteratorAggregate) {
+			return $this->resolveProducedIterable($source->getIterator());
 		}
 
 		if ($this->consumed) {
@@ -130,6 +127,28 @@ trait SequenceLogic
 		$this->consumed = true;
 
 		return $source;
+	}
+
+	/**
+	 * Rejects a producer - a source Closure or an IteratorAggregate - handing back the
+	 * cursor of the previous pass: implementing IteratorAggregate promises nothing about
+	 * replayability, getIterator() is free to return a Generator the object keeps around,
+	 * and traversing that one again would yield nothing (or leak a raw PHP error).
+	 *
+	 * @param iterable<E> $produced
+	 * @return iterable<E>
+	 */
+	private function resolveProducedIterable(iterable $produced): iterable
+	{
+		if ($produced instanceof Traversable && !$produced instanceof IteratorAggregate) {
+			if ($produced === $this->lastProduced) {
+				throw SequenceAlreadyIteratedException::sourceReturnedSameIterator();
+			}
+
+			$this->lastProduced = $produced;
+		}
+
+		return $produced;
 	}
 
 	/**

--- a/src/functions.php
+++ b/src/functions.php
@@ -204,9 +204,9 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	 * sequence can be iterated again depends on the source kind (see Sequence for the
 	 * full contract):
 	 *
-	 * - an array or an IteratorAggregate (e.g. a Collection): replayable;
-	 * - a Closure: a producer, re-invoked on every pass; it must return a fresh iterable
-	 *   on each call;
+	 * - an array: replayable;
+	 * - a Closure or an IteratorAggregate (e.g. a Collection): a producer, asked for an
+	 *   iterable on every pass; it must hand back a fresh iterator each time;
 	 * - a raw Iterator/Generator: single-pass, yields its remaining elements.
 	 *
 	 * @template E

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,6 +22,8 @@ use Noctud\Collection\Map\IntMap\MutableIntMap;
 use Noctud\Collection\Map\MutableMap;
 use Noctud\Collection\Map\StringMap\ImmutableStringMap;
 use Noctud\Collection\Map\StringMap\MutableStringMap;
+use Noctud\Collection\Sequence\GeneratorSequence;
+use Noctud\Collection\Sequence\Sequence;
 use Noctud\Collection\Set\HashSet\ImmutableHashSet;
 use Noctud\Collection\Set\HashSet\MutableHashSet;
 use Noctud\Collection\Set\ImmutableSet;
@@ -194,5 +196,25 @@ if (!function_exists('Noctud\Collection\listOf')) {
 	function mutableIntMapOf(iterable|Closure|null $data = null): MutableMap
 	{
 		return new MutableIntMap($data ?? []);
+	}
+
+	/**
+	 * Creates a lazy sequence over the given source.
+	 * Nothing is pulled from the source before the sequence is iterated. Whether the
+	 * sequence can be iterated again depends on the source kind (see Sequence for the
+	 * full contract):
+	 *
+	 * - an array or an IteratorAggregate (e.g. a Collection): replayable;
+	 * - a Closure: a producer, re-invoked on every pass; it must return a fresh iterable
+	 *   on each call;
+	 * - a raw Iterator/Generator: single-pass, yields its remaining elements.
+	 *
+	 * @template E
+	 * @param iterable<E>|Closure():iterable<E> $source
+	 * @return Sequence<E>
+	 */
+	function sequenceOf(iterable|Closure $source = []): Sequence
+	{
+		return new GeneratorSequence($source);
 	}
 }

--- a/tests/Sequence/Fixture/GeneratorAggregate.php
+++ b/tests/Sequence/Fixture/GeneratorAggregate.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence\Fixture;
+
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * IteratorAggregate whose getIterator() is a generator function: every call hands out a
+ * fresh Generator, so the aggregate replays (the shape of the library's own map views).
+ *
+ * @template TValue
+ * @implements IteratorAggregate<int, TValue>
+ */
+final class GeneratorAggregate implements IteratorAggregate
+{
+	/** @param list<TValue> $values */
+	public function __construct(
+		private readonly array $values,
+	) {}
+
+	/** @return Traversable<int, TValue> */
+	public function getIterator(): Traversable
+	{
+		yield from $this->values;
+	}
+}

--- a/tests/Sequence/Fixture/SharedIteratorAggregate.php
+++ b/tests/Sequence/Fixture/SharedIteratorAggregate.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence\Fixture;
+
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * IteratorAggregate handing back the very same traversable on every call: implementing
+ * IteratorAggregate is no promise of replayability.
+ *
+ * @template TKey
+ * @template TValue
+ * @implements IteratorAggregate<TKey, TValue>
+ */
+final class SharedIteratorAggregate implements IteratorAggregate
+{
+	/** @param Traversable<TKey, TValue> $iterator */
+	public function __construct(
+		private readonly Traversable $iterator,
+	) {}
+
+	/** @return Traversable<TKey, TValue> */
+	public function getIterator(): Traversable
+	{
+		return $this->iterator;
+	}
+}

--- a/tests/Sequence/SequenceFactoryTest.php
+++ b/tests/Sequence/SequenceFactoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence;
+
+use Countable;
+use JsonSerializable;
+use Noctud\Collection\Collection;
+use Noctud\Collection\List\ImmutableList;
+use Noctud\Collection\Set\ImmutableSet;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\sequenceOf;
+
+final class SequenceFactoryTest extends TestCase
+{
+	#[Test]
+	public function sequenceOf_defaults_to_an_empty_sequence(): void
+	{
+		$this->assertSame([], sequenceOf()->toArray());
+	}
+
+	#[Test]
+	public function sequenceOf_accepts_an_array(): void
+	{
+		$this->assertSame([1, 2, 3], sequenceOf([1, 2, 3])->toArray());
+	}
+
+	#[Test]
+	public function sequenceOf_accepts_a_collection(): void
+	{
+		$this->assertSame([1, 2, 3], sequenceOf(listOf([1, 2, 3]))->toArray());
+	}
+
+	#[Test]
+	public function sequenceOf_accepts_a_raw_generator(): void
+	{
+		$generator = (static function () {
+			yield 1;
+			yield 2;
+		})();
+
+		$this->assertSame([1, 2], sequenceOf($generator)->toArray());
+	}
+
+	#[Test]
+	public function sequenceOf_accepts_a_closure(): void
+	{
+		$this->assertSame([1, 2, 3], sequenceOf(static fn (): array => [1, 2, 3])->toArray());
+	}
+
+	#[Test]
+	public function sequence_is_not_collection_countable_or_json_serializable(): void
+	{
+		$sequence = sequenceOf([1]);
+
+		$this->assertNotInstanceOf(Collection::class, $sequence);
+		$this->assertNotInstanceOf(Countable::class, $sequence);
+		$this->assertNotInstanceOf(JsonSerializable::class, $sequence);
+	}
+
+	#[Test]
+	public function closure_source_is_invoked_lazily_at_consumption(): void
+	{
+		$invocations = 0;
+		$sequence = sequenceOf(static function () use (&$invocations): array {
+			$invocations++;
+
+			return [1, 2];
+		});
+
+		$this->assertSame(0, $invocations);
+		$this->assertSame([1, 2], $sequence->toArray());
+		$this->assertSame(1, $invocations);
+	}
+
+	#[Test]
+	public function toArray_returns_a_reindexed_list(): void
+	{
+		$this->assertSame([1, 2, 3], sequenceOf(['a' => 1, 'b' => 2, 'c' => 3])->toArray());
+	}
+
+	#[Test]
+	public function toList_returns_an_immutable_list(): void
+	{
+		$list = sequenceOf([1, 2, 3])->toList();
+
+		$this->assertInstanceOf(ImmutableList::class, $list);
+		$this->assertSame([1, 2, 3], $list->toArray());
+	}
+
+	#[Test]
+	public function toSet_returns_an_immutable_set_with_duplicates_removed(): void
+	{
+		$set = sequenceOf([1, 2, 2, 3, 1])->toSet();
+
+		$this->assertInstanceOf(ImmutableSet::class, $set);
+		$this->assertSame([1, 2, 3], $set->toArray());
+	}
+
+	#[Test]
+	public function foreach_yields_fresh_positional_keys(): void
+	{
+		$sequence = sequenceOf(['x' => 'a', 'y' => 'b']);
+
+		$firstPassKeys = [];
+		foreach ($sequence as $key => $value) {
+			$firstPassKeys[] = $key;
+		}
+
+		$secondPassKeys = [];
+		foreach ($sequence as $key => $value) {
+			$secondPassKeys[] = $key;
+		}
+
+		$this->assertSame([0, 1], $firstPassKeys);
+		$this->assertSame([0, 1], $secondPassKeys);
+	}
+}

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -14,7 +14,10 @@ use Exception;
 use Generator;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
 use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Sequence\GeneratorSequence;
+use Noctud\Collection\Tests\Sequence\Fixture\GeneratorAggregate;
+use Noctud\Collection\Tests\Sequence\Fixture\SharedIteratorAggregate;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function Noctud\Collection\listOf;
@@ -64,6 +67,54 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1, 2], $sequence->toArray());
 		$this->assertSame([1, 2], $sequence->toArray());
+	}
+
+	#[Test]
+	public function aggregate_source_returning_a_fresh_generator_replays(): void
+	{
+		$sequence = sequenceOf(new GeneratorAggregate([1, 2, 3]));
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+	}
+
+	#[Test]
+	public function aggregate_source_holding_on_to_its_iterator_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+		})();
+		$sequence = sequenceOf(new SharedIteratorAggregate($generator));
+
+		$this->assertSame([1], $sequence->toArray());
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectExceptionMessageIsOrContains(
+			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
+		);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function aggregate_source_delegating_to_an_inner_collection_replays(): void
+	{
+		// The same inner aggregate every pass is legitimate: it is itself a producer,
+		// re-invoked by the foreach that unwraps it.
+		$sequence = sequenceOf(new SharedIteratorAggregate(listOf([1, 2, 3])));
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+	}
+
+	#[Test]
+	public function closure_returning_the_same_collection_replays(): void
+	{
+		$list = listOf([1, 2, 3]);
+		$sequence = sequenceOf(static fn (): ImmutableList => $list);
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+		$this->assertSame([1, 2, 3], $sequence->toArray());
 	}
 
 	#[Test]
@@ -125,7 +176,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 		$this->expectExceptionMessageIsOrContains(
-			'The sequence\'s source closure returned the same iterator instance again - it must produce a fresh iterable on each call.',
+			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
 		$sequence->toArray();

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Noctud\Collection\Tests\Sequence;
 
 use ArrayIterator;
+use Exception;
 use Generator;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
 use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
@@ -126,6 +127,33 @@ final class SequenceIterationTest extends TestCase
 		$this->expectExceptionMessageIsOrContains(
 			'The sequence\'s source closure returned the same iterator instance again - it must produce a fresh iterable on each call.',
 		);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function producer_cycling_between_iterators_slips_past_the_guard_and_leaks_the_raw_php_error(): void
+	{
+		$first = (static function (): Generator {
+			yield 1;
+		})();
+		$second = (static function (): Generator {
+			yield 2;
+		})();
+		// The identity guard remembers only the previous pass's iterator, so a producer
+		// alternating between two exhausted generators bypasses it. Known accepted
+		// limitation: catching this would require tracking every produced iterator
+		// (unbounded memory), so the raw PHP error surfaces instead of ours.
+		$passes = 0;
+		$sequence = sequenceOf(static function () use ($first, $second, &$passes): Generator {
+			return ++$passes % 2 === 1 ? $first : $second;
+		});
+
+		$this->assertSame([1], $sequence->toArray());
+		$this->assertSame([2], $sequence->toArray());
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageIsOrContains('Cannot traverse an already closed generator');
 
 		$sequence->toArray();
 	}

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -93,7 +93,8 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -138,14 +139,15 @@ final class SequenceIterationTest extends TestCase
 		})();
 		$sequence = sequenceOf($generator);
 
-		$sequence->toArray();
+		self::assertSame([1], $sequence->toArray());
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
 		);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -157,7 +159,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -172,14 +175,15 @@ final class SequenceIterationTest extends TestCase
 			return $generator;
 		});
 
-		$sequence->toArray();
+        $this->assertSame([1], $sequence->toArray());
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -202,7 +206,8 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessageIsOrContains('Cannot traverse an already closed generator');
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -214,7 +219,8 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(InvalidSequenceSourceException::class);
 		$this->expectExceptionMessageIsOrContains('The sequence\'s source closure must return an iterable, got int.');
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -231,7 +237,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -255,7 +262,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-		$sequence->toArray();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -270,6 +278,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-		$sequence->getIterator();
+        // phpcs:ignore
+        $_ = $sequence->toArray();
 	}
 }

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -20,6 +20,7 @@ use Noctud\Collection\Tests\Sequence\Fixture\GeneratorAggregate;
 use Noctud\Collection\Tests\Sequence\Fixture\SharedIteratorAggregate;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use WeakReference;
 use function Noctud\Collection\listOf;
 use function Noctud\Collection\mutableListOf;
 use function Noctud\Collection\sequenceOf;
@@ -119,6 +120,29 @@ final class SequenceIterationTest extends TestCase
 	}
 
 	#[Test]
+	public function a_consumed_iterator_is_not_retained_by_the_sequence(): void
+	{
+		$weak = null;
+		$sequence = sequenceOf(static function () use (&$weak): Generator {
+			$generator = (static function (): Generator {
+				yield 1;
+			})();
+			$weak = WeakReference::create($generator);
+
+			return $generator;
+		});
+
+		$this->assertSame([1], $sequence->toArray());
+
+		gc_collect_cycles();
+
+		// The identity guard holds the previous pass's cursor weakly, so nothing keeps a
+		// consumed iterator - nor the handle or cursor behind it - alive.
+		$this->assertNull($weak?->get());
+		$this->assertSame([1], $sequence->toArray());
+	}
+
+	#[Test]
 	public function replay_sees_live_collection_mutations(): void
 	{
 		$list = mutableListOf([1, 2]);
@@ -175,7 +199,27 @@ final class SequenceIterationTest extends TestCase
 			return $generator;
 		});
 
-        $this->assertSame([1], $sequence->toArray());
+		$this->assertSame([1], $sequence->toArray());
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectExceptionMessageIsOrContains(
+			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
+		);
+
+        // phpcs:ignore
+        $_ = $sequence->toArray();
+	}
+
+	#[Test]
+	public function closure_returning_an_aggregate_holding_on_to_its_iterator_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+		})();
+		$aggregate = new SharedIteratorAggregate($generator);
+		$sequence = sequenceOf(static fn (): SharedIteratorAggregate => $aggregate);
+
+		$this->assertSame([1], $sequence->toArray());
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 		$this->expectExceptionMessageIsOrContains(

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence;
+
+use ArrayIterator;
+use Generator;
+use Noctud\Collection\Exception\InvalidSequenceSourceException;
+use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\Sequence\GeneratorSequence;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\mutableListOf;
+use function Noctud\Collection\sequenceOf;
+
+final class SequenceIterationTest extends TestCase
+{
+	#[Test]
+	public function array_source_replays(): void
+	{
+		$sequence = sequenceOf([1, 2, 3]);
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+	}
+
+	#[Test]
+	public function collection_source_replays(): void
+	{
+		$sequence = sequenceOf(listOf([1, 2, 3]));
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+	}
+
+	#[Test]
+	public function fresh_closure_source_replays_by_reinvoking_the_producer(): void
+	{
+		$invocations = 0;
+		$sequence = sequenceOf(static function () use (&$invocations): Generator {
+			$invocations++;
+
+			yield 1;
+			yield 2;
+		});
+
+		$this->assertSame([1, 2], $sequence->toArray());
+		$this->assertSame([1, 2], $sequence->toArray());
+		$this->assertSame(2, $invocations);
+	}
+
+	#[Test]
+	public function closure_returning_an_array_replays(): void
+	{
+		$sequence = sequenceOf(static fn (): array => [1, 2]);
+
+		$this->assertSame([1, 2], $sequence->toArray());
+		$this->assertSame([1, 2], $sequence->toArray());
+	}
+
+	#[Test]
+	public function replay_sees_live_collection_mutations(): void
+	{
+		$list = mutableListOf([1, 2]);
+		$sequence = sequenceOf($list);
+
+		$this->assertSame([1, 2], $sequence->toArray());
+
+		$list->add(3);
+
+		$this->assertSame([1, 2, 3], $sequence->toArray());
+	}
+
+	#[Test]
+	public function raw_generator_source_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+		})();
+		$sequence = sequenceOf($generator);
+
+		$sequence->toArray();
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectExceptionMessageIsOrContains(
+			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
+		);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function raw_iterator_source_is_one_shot_even_if_rewindable(): void
+	{
+		$sequence = sequenceOf(new ArrayIterator([1, 2]));
+
+		$this->assertSame([1, 2], $sequence->toArray());
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function closure_returning_the_same_generator_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+		})();
+		// By-ref capture keeps this a regular closure: an arrow fn whose body evaluates
+		// to a Generator trips phpstan's return.void check (generator-function confusion).
+		$sequence = sequenceOf(static function () use (&$generator): Generator {
+			return $generator;
+		});
+
+		$sequence->toArray();
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectExceptionMessageIsOrContains(
+			'The sequence\'s source closure returned the same iterator instance again - it must produce a fresh iterable on each call.',
+		);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function closure_returning_a_non_iterable_throws_at_consumption(): void
+	{
+		/** @phpstan-ignore argument.type, argument.templateType */
+		$sequence = sequenceOf(static fn (): int => 42);
+
+		$this->expectException(InvalidSequenceSourceException::class);
+		$this->expectExceptionMessageIsOrContains('The sequence\'s source closure must return an iterable, got int.');
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function toSet_consumes_a_pass_of_a_one_shot_source(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+			yield 2;
+			yield 1;
+		})();
+		$sequence = sequenceOf($generator);
+
+		$this->assertSame([1, 2], $sequence->toSet()->toArray());
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function partially_consumed_one_shot_source_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+			yield 2;
+			yield 3;
+		})();
+		$sequence = sequenceOf($generator);
+
+		$first = null;
+		foreach ($sequence as $value) {
+			$first = $value;
+
+			break;
+		}
+
+		$this->assertSame(1, $first);
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+		$sequence->toArray();
+	}
+
+	#[Test]
+	public function second_pass_throws_at_getIterator_not_at_first_advance(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+		})();
+		$sequence = new GeneratorSequence($generator);
+
+		$sequence->getIterator();
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+		$sequence->getIterator();
+	}
+}

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -140,13 +140,9 @@ final class SequenceIterationTest extends TestCase
 		$second = (static function (): Generator {
 			yield 2;
 		})();
-		// The identity guard remembers only the previous pass's iterator, so a producer
-		// alternating between two exhausted generators bypasses it. Known accepted
-		// limitation: catching this would require tracking every produced iterator
-		// (unbounded memory), so the raw PHP error surfaces instead of ours.
-		$passes = 0;
-		$sequence = sequenceOf(static function () use ($first, $second, &$passes): Generator {
-			return ++$passes % 2 === 1 ? $first : $second;
+		$n = 0;
+		$sequence = sequenceOf(static function () use ($first, $second, &$n): Generator {
+			return $n++ % 2 === 0 ? $first : $second;
 		});
 
 		$this->assertSame([1], $sequence->toArray());

--- a/tests/Sequence/SequenceLazinessTest.php
+++ b/tests/Sequence/SequenceLazinessTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence;
+
+use Generator;
+use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function Noctud\Collection\sequenceOf;
+
+final class SequenceLazinessTest extends TestCase
+{
+	#[Test]
+	public function nothing_runs_before_terminal(): void
+	{
+		$invocations = 0;
+		$predicateCalls = 0;
+		$transformCalls = 0;
+
+		$sequence = sequenceOf(static function () use (&$invocations): array {
+			$invocations++;
+
+			return [1, 2, 3];
+		})
+			->filter(static function (int $v) use (&$predicateCalls): bool {
+				$predicateCalls++;
+
+				return $v > 1;
+			})
+			->map(static function (int $v) use (&$transformCalls): int {
+				$transformCalls++;
+
+				return $v * 10;
+			});
+
+		$this->assertSame(0, $invocations);
+		$this->assertSame(0, $predicateCalls);
+		$this->assertSame(0, $transformCalls);
+
+		$this->assertSame([20, 30], $sequence->toArray());
+
+		$this->assertSame(1, $invocations);
+		$this->assertSame(3, $predicateCalls);
+		$this->assertSame(2, $transformCalls);
+	}
+
+	#[Test]
+	public function filter_map_fusion_processes_elements_one_by_one(): void
+	{
+		$log = [];
+
+		$result = sequenceOf([1, 2, 3, 4, 5, 6])
+			->filter(static function (int $v) use (&$log): bool {
+				$log[] = "f:$v";
+
+				return $v % 2 === 0;
+			})
+			->map(static function (int $v) use (&$log): int {
+				$log[] = "m:$v";
+
+				return $v * 10;
+			})
+			->toArray();
+
+		$this->assertSame([20, 40, 60], $result);
+		$this->assertSame(
+			['f:1', 'f:2', 'm:2', 'f:3', 'f:4', 'm:4', 'f:5', 'f:6', 'm:6'],
+			$log,
+		);
+	}
+
+	#[Test]
+	public function chained_pipeline_replays_through_replayable_root(): void
+	{
+		$sequence = sequenceOf([1, 2, 3])
+			->filter(static fn (int $v): bool => $v > 1)
+			->map(static fn (int $v): int => $v * 10);
+
+		$this->assertSame([20, 30], $sequence->toArray());
+		$this->assertSame([20, 30], $sequence->toArray());
+	}
+
+	#[Test]
+	public function chained_pipeline_throws_through_one_shot_root(): void
+	{
+		$generator = (static function (): Generator {
+			yield 1;
+			yield 2;
+		})();
+		$sequence = sequenceOf($generator)
+			->filter(static fn (int $v): bool => $v > 0)
+			->map(static fn (int $v): int => $v * 10);
+
+		$this->assertSame([10, 20], $sequence->toArray());
+
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+		$sequence->toArray();
+	}
+}

--- a/tests/Sequence/SequenceLazinessTest.php
+++ b/tests/Sequence/SequenceLazinessTest.php
@@ -102,6 +102,7 @@ final class SequenceLazinessTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-		$sequence->toArray();
+        // phpcs:ignore
+		$_ = $sequence->toArray();
 	}
 }

--- a/tests/Sequence/SequenceTransformTest.php
+++ b/tests/Sequence/SequenceTransformTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\sequenceOf;
+
+final class SequenceTransformTest extends TestCase
+{
+	#[Test]
+	public function filter_keeps_matching_elements_reindexed(): void
+	{
+		$this->assertSame([2, 4], sequenceOf([1, 2, 3, 4])->filter(static fn (int $v): bool => $v % 2 === 0)->toArray());
+	}
+
+	#[Test]
+	public function filter_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3, 4, 5];
+		$predicate = static fn (int $v): bool => $v % 2 === 1;
+
+		$this->assertSame(
+			listOf($data)->filter($predicate)->toArray(),
+			sequenceOf($data)->filter($predicate)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function map_transforms_each_element(): void
+	{
+		$this->assertSame(
+			['1', '2'],
+			sequenceOf([1, 2])
+				->map(static fn (int $v): string => (string) $v)
+				->toArray()
+		);
+	}
+
+	#[Test]
+	public function map_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3];
+		$transform = static fn (int $v): int => $v * $v;
+
+		$this->assertSame(
+			listOf($data)->map($transform)->toArray(),
+			sequenceOf($data)->map($transform)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function predicate_receives_positional_index(): void
+	{
+		$this->assertSame(
+			['a', 'c'],
+			sequenceOf(['a', 'b', 'c', 'd'])->filter(static fn (string $v, int $i): bool => $i % 2 === 0)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function map_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c', 'd'])
+			->filter(static fn (string $v): bool => $v !== 'b')
+			->map(static fn (string $v, int $i): string => "$i:$v")
+			->toArray();
+
+		$this->assertSame(['0:a', '1:c', '2:d'], $result);
+	}
+}

--- a/tests/Type/SequenceTransformTypeTest.php
+++ b/tests/Type/SequenceTransformTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Type;
+
+use function Noctud\Collection\sequenceOf;
+use function PHPStan\Testing\assertType;
+
+// filter() preserves the element type.
+assertType('Noctud\Collection\Sequence\Sequence<int>', sequenceOf([1, 2, 3])->filter(static fn (int $v): bool => $v > 1));
+
+// map() infers the new element type from the transform return.
+assertType('Noctud\Collection\Sequence\Sequence<bool>', sequenceOf([1, 2, 3])->map(static fn (int $v): bool => $v > 1));
+
+// A fused filter->map chain carries types through both stages.
+assertType(
+	'Noctud\Collection\Sequence\Sequence<float>',
+	sequenceOf([1, 2, 3])->filter(static fn (int $v): bool => $v > 1)->map(static fn (int $v): float => $v * 2.5),
+);


### PR DESCRIPTION
see https://github.com/noctud/collection/issues/23

Here is a first PR which paves the way for lazy sequences: new type is created + iteration ("re-playability" handled) + 2 intermediates (`filter()` and `map()`) and few terminals (`toArray()`, `toList()`, `toSet()`

I think this is enough for a first iteration, so that we can discuss on concrete code