### PR TITLE
[Sequence] Add "intermediate" methods

### DIFF
--- a/docs/collection/api/collection.md
+++ b/docs/collection/api/collection.md
@@ -312,6 +312,10 @@ zip(iterable $other): ListInterface<array{E, U}>
 ```
 Pair elements from two iterables at the same position. Result length equals the shorter input.
 
+::: tip Resuming an advanced iterator
+Only a `Generator` can be distinguished from a fresh cursor — every other advanced iterator is indistinguishable from an unstarted one and gets rewound. Wrap it in a `NoRewindIterator` to resume it where it stands instead.
+:::
+
 ```php
 zipWithNext(): ListInterface<array{E, E}>
 ```

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -537,6 +537,10 @@ interface Collection extends IteratorAggregate, Countable, JsonSerializable
 	 * Combines this collection with another iterable by pairing elements at the same position.
 	 * The resulting collection has the length of the shorter input.
 	 *
+	 * The other side is pulled in lockstep rather than copied, and rewound first just as
+	 * foreach would rewind it: an already started Generator therefore throws. Wrap it in a
+	 * NoRewindIterator to deliberately resume a cursor that is already in flight.
+	 *
 	 * @template U
 	 * @param iterable<U> $other
 	 * @return ListInterface<array{E, U}>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -537,9 +537,10 @@ interface Collection extends IteratorAggregate, Countable, JsonSerializable
 	 * Combines this collection with another iterable by pairing elements at the same position.
 	 * The resulting collection has the length of the shorter input.
 	 *
-	 * The other side is pulled in lockstep rather than copied, and rewound first just as
-	 * foreach would rewind it: an already started Generator therefore throws. Wrap it in a
-	 * NoRewindIterator to deliberately resume a cursor that is already in flight.
+	 * The other side is pulled in lockstep rather than copied. A Generator resumes from its
+	 * current position, so the head of a stream can be consumed before zipping the rest; any
+	 * other iterator is rewound first, and an already advanced one therefore restarts from its
+	 * first element - wrap it in a NoRewindIterator to resume it instead.
 	 *
 	 * @template U
 	 * @param iterable<U> $other

--- a/src/CollectionLogic.php
+++ b/src/CollectionLogic.php
@@ -598,20 +598,14 @@ trait CollectionLogic
 	#[NoDiscard]
 	public function takeWhile(Closure $predicate): ImmutableCollection
 	{
-		$i = 0;
-		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate($predicate));
 	}
 
 	/** {@inheritDoc} */
 	#[NoDiscard]
 	public function dropWhile(Closure $predicate): ImmutableCollection
 	{
-		$i = 0;
-		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate($predicate));
 	}
 
 	/** {@inheritDoc} */

--- a/src/Exception/NonReplayableSourceException.php
+++ b/src/Exception/NonReplayableSourceException.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Exception;
 
+use Throwable;
+
 /**
  * Thrown when an iterable that can only be walked once is walked again.
  */
@@ -24,7 +26,15 @@ final class NonReplayableSourceException extends UnsupportedOperationException
 	public static function zippedIterableAlreadyIterated(): self
 	{
 		return new self(
-			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate - a collection or a sequence, for instance - to iterate the result more than once.',
+			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate to iterate the result more than once.',
+		);
+	}
+
+	public static function zippedIterableCannotRewind(Throwable $cause): self
+	{
+		return new self(
+			'The iterable passed to zip() could not be rewound, so it cannot be walked from its start.',
+			previous: $cause,
 		);
 	}
 

--- a/src/Exception/NonReplayableSourceException.php
+++ b/src/Exception/NonReplayableSourceException.php
@@ -10,16 +10,21 @@ declare(strict_types=1);
 namespace Noctud\Collection\Exception;
 
 /**
- * Thrown when a sequence backed by a non-replayable source is iterated a second time,
- * or when a sequence source - a closure or an IteratorAggregate - hands back the same
- * iterator instance twice.
+ * Thrown when an iterable that can only be walked once is walked again.
  */
-final class SequenceAlreadyIteratedException extends UnsupportedOperationException
+final class NonReplayableSourceException extends UnsupportedOperationException
 {
-	public static function nonReplayableSourceAlreadyIterated(): self
+	public static function sequenceSourceAlreadyIterated(): self
 	{
 		return new self(
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
+		);
+	}
+
+	public static function zippedIterableAlreadyIterated(): self
+	{
+		return new self(
+			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate - a collection or a sequence, for instance - to iterate the result more than once.',
 		);
 	}
 

--- a/src/List/ListLogic.php
+++ b/src/List/ListLogic.php
@@ -299,10 +299,7 @@ trait ListLogic
 	#[NoDiscard]
 	public function takeWhile(Closure $predicate): ImmutableList
 	{
-		$i = 0;
-		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate($predicate));
 	}
 
 	/**
@@ -313,10 +310,7 @@ trait ListLogic
 	#[NoDiscard]
 	public function dropWhile(Closure $predicate): ImmutableList
 	{
-		$i = 0;
-		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate($predicate));
 	}
 
 	/**

--- a/src/Operation/DropOperation.php
+++ b/src/Operation/DropOperation.php
@@ -50,14 +50,14 @@ final class DropOperation extends AbstractOperation
 	}
 
 	/**
-	 * @param callable(V):bool $predicate
+	 * @param callable(V, int):bool $predicate
 	 * @return Generator<V>
 	 */
 	public function byPredicate(callable $predicate): Generator
 	{
 		$dropping = true;
-		foreach ($this->data as $v) {
-			if ($dropping && $predicate($v)) {
+		foreach ($this->data as $i => $v) {
+			if ($dropping && $predicate($v, $i)) {
 				continue;
 			}
 			$dropping = false;

--- a/src/Operation/TakeOperation.php
+++ b/src/Operation/TakeOperation.php
@@ -30,10 +30,11 @@ final class TakeOperation extends AbstractOperation
 
 		$i = 0;
 		foreach ($this->data as $v) {
-			if ($i++ >= $n) {
+			yield $v;
+
+			if (++$i >= $n) {
 				break;
 			}
-			yield $v;
 		}
 	}
 
@@ -53,13 +54,13 @@ final class TakeOperation extends AbstractOperation
 	}
 
 	/**
-	 * @param callable(V):bool $predicate
+	 * @param callable(V, int):bool $predicate
 	 * @return Generator<V>
 	 */
 	public function byPredicate(callable $predicate): Generator
 	{
-		foreach ($this->data as $v) {
-			if (!$predicate($v)) {
+		foreach ($this->data as $i => $v) {
+			if (!$predicate($v, $i)) {
 				break;
 			}
 			yield $v;

--- a/src/Operation/ZipOperation.php
+++ b/src/Operation/ZipOperation.php
@@ -58,9 +58,14 @@ final class ZipOperation extends AbstractOperation
 	 * Positioned cursor over any iterable, so both sides can be walked in lockstep without
 	 * either being buffered.
 	 *
-	 * The rewind is not optional: an SplDoublyLinkedList and every IteratorIterator decorator
-	 * answer valid() === false until rewound, which lockstep would read as an empty side. It
-	 * makes a started Generator throw, exactly as foreach does; NoRewindIterator opts out.
+	 * A Generator is always positioned - valid() primes it - so valid() === false means
+	 * exhausted, never "not started". Left alone, it resumes from wherever it stands, which is
+	 * what lets a caller consume the head of a stream and zip the rest.
+	 *
+	 * Every other Iterator holds no position until rewound: an SplDoublyLinkedList and every
+	 * IteratorIterator decorator answer valid() === false beforehand, which lockstep would read
+	 * as an empty side. They are rewound, so one already advanced restarts from its first
+	 * element - it cannot be told apart from a fresh one - and NoRewindIterator opts out.
 	 *
 	 * @template T
 	 * @param iterable<T> $iterable
@@ -70,6 +75,10 @@ final class ZipOperation extends AbstractOperation
 	{
 		if (is_array($iterable)) {
 			return new ArrayIterator($iterable);
+		}
+
+		if ($iterable instanceof Generator) {
+			return $iterable;
 		}
 
 		$cursor = $iterable instanceof Iterator ? $iterable : new IteratorIterator($iterable);

--- a/src/Operation/ZipOperation.php
+++ b/src/Operation/ZipOperation.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Operation;
 
+use ArrayIterator;
 use Generator;
-use Traversable;
+use Iterator;
+use IteratorIterator;
 
 /**
  * @internal
@@ -26,17 +28,50 @@ final class ZipOperation extends AbstractOperation
 	 */
 	public function with(iterable $other): Generator
 	{
-		$otherArray = $other instanceof Traversable ? iterator_to_array($other, false) : array_values($other);
-		$otherCount = count($otherArray);
-		$i = 0;
+		$left = self::cursor($this->data);
+		$right = self::cursor($other);
 
-		foreach ($this->data as $v) {
-			if ($i >= $otherCount) {
+		while ($left->valid() && $right->valid()) {
+			yield [$left->current(), $right->current()];
+
+			// Advancing the other side only once this one still has an element spares it a
+			// pull that would be thrown away whenever this side is the shorter one.
+			$left->next();
+
+			if (!$left->valid()) {
 				break;
 			}
 
-			yield [$v, $otherArray[$i]];
-			$i++;
+			$right->next();
 		}
+	}
+
+	/**
+	 * Positioned cursor over any iterable, so both sides can be walked in lockstep without
+	 * either being buffered.
+	 *
+	 * An Iterator is used as is and never rewound: it may be a cursor that has already
+	 * started, and rewinding a running Generator throws.
+	 *
+	 * @template T
+	 * @param iterable<T> $iterable
+	 * @return Iterator<T>
+	 */
+	private static function cursor(iterable $iterable): Iterator
+	{
+		if (is_array($iterable)) {
+			return new ArrayIterator($iterable);
+		}
+
+		if ($iterable instanceof Iterator) {
+			return $iterable;
+		}
+
+		// An IteratorAggregate only hands out its iterator on rewind(): before that the
+		// wrapper has no position at all, and valid() answers false.
+		$cursor = new IteratorIterator($iterable);
+		$cursor->rewind();
+
+		return $cursor;
 	}
 }

--- a/src/Operation/ZipOperation.php
+++ b/src/Operation/ZipOperation.php
@@ -13,6 +13,9 @@ use ArrayIterator;
 use Generator;
 use Iterator;
 use IteratorIterator;
+use Noctud\Collection\Exception\NonReplayableSourceException;
+use NoRewindIterator;
+use Throwable;
 
 /**
  * @internal
@@ -25,6 +28,7 @@ final class ZipOperation extends AbstractOperation
 	 * @template U
 	 * @param iterable<U> $other
 	 * @return Generator<array{V, U}>
+	 * @throws NonReplayableSourceException If the other side cannot be positioned at its start
 	 */
 	public function with(iterable $other): Generator
 	{
@@ -55,17 +59,16 @@ final class ZipOperation extends AbstractOperation
 	}
 
 	/**
+	 * @param iterable<mixed> $iterable
+	 */
+	public static function isReplayable(iterable $iterable): bool
+	{
+		return !$iterable instanceof Generator && !$iterable instanceof NoRewindIterator;
+	}
+
+	/**
 	 * Positioned cursor over any iterable, so both sides can be walked in lockstep without
 	 * either being buffered.
-	 *
-	 * A Generator is always positioned - valid() primes it - so valid() === false means
-	 * exhausted, never "not started". Left alone, it resumes from wherever it stands, which is
-	 * what lets a caller consume the head of a stream and zip the rest.
-	 *
-	 * Every other Iterator holds no position until rewound: an SplDoublyLinkedList and every
-	 * IteratorIterator decorator answer valid() === false beforehand, which lockstep would read
-	 * as an empty side. They are rewound, so one already advanced restarts from its first
-	 * element - it cannot be told apart from a fresh one - and NoRewindIterator opts out.
 	 *
 	 * @template T
 	 * @param iterable<T> $iterable
@@ -77,12 +80,19 @@ final class ZipOperation extends AbstractOperation
 			return new ArrayIterator($iterable);
 		}
 
-		if ($iterable instanceof Generator) {
-			return $iterable;
+		$cursor = $iterable instanceof Iterator ? $iterable : new IteratorIterator($iterable);
+
+		// Asked rather than decided again, so that what counts as replayable and what actually
+		// gets repositioned cannot drift apart.
+		if (!self::isReplayable($iterable)) {
+			return $cursor;
 		}
 
-		$cursor = $iterable instanceof Iterator ? $iterable : new IteratorIterator($iterable);
-		$cursor->rewind();
+		try {
+			$cursor->rewind();
+		} catch (Throwable $e) {
+			throw NonReplayableSourceException::zippedIterableCannotRewind($e);
+		}
 
 		return $cursor;
 	}

--- a/src/Operation/ZipOperation.php
+++ b/src/Operation/ZipOperation.php
@@ -29,9 +29,17 @@ final class ZipOperation extends AbstractOperation
 	public function with(iterable $other): Generator
 	{
 		$left = self::cursor($this->data);
+
+		// Positioning the other side would pull an element no pair could ever use.
+		if (!$left->valid()) {
+			return;
+		}
+
 		$right = self::cursor($other);
 
-		while ($left->valid() && $right->valid()) {
+		// This side is known to hold an element on every entry: the check above covers the
+		// first one, the break below every later one.
+		while ($right->valid()) {
 			yield [$left->current(), $right->current()];
 
 			// Advancing the other side only once this one still has an element spares it a
@@ -50,8 +58,9 @@ final class ZipOperation extends AbstractOperation
 	 * Positioned cursor over any iterable, so both sides can be walked in lockstep without
 	 * either being buffered.
 	 *
-	 * An Iterator is used as is and never rewound: it may be a cursor that has already
-	 * started, and rewinding a running Generator throws.
+	 * The rewind is not optional: an SplDoublyLinkedList and every IteratorIterator decorator
+	 * answer valid() === false until rewound, which lockstep would read as an empty side. It
+	 * makes a started Generator throw, exactly as foreach does; NoRewindIterator opts out.
 	 *
 	 * @template T
 	 * @param iterable<T> $iterable
@@ -63,13 +72,7 @@ final class ZipOperation extends AbstractOperation
 			return new ArrayIterator($iterable);
 		}
 
-		if ($iterable instanceof Iterator) {
-			return $iterable;
-		}
-
-		// An IteratorAggregate only hands out its iterator on rewind(): before that the
-		// wrapper has no position at all, and valid() answers false.
-		$cursor = new IteratorIterator($iterable);
+		$cursor = $iterable instanceof Iterator ? $iterable : new IteratorIterator($iterable);
 		$cursor->rewind();
 
 		return $cursor;

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -56,6 +56,24 @@ interface Sequence extends IteratorAggregate
 	public function filter(Closure $predicate): Sequence;
 
 	/**
+	 * Filter non-null elements.
+	 *
+	 * @return Sequence<(E is null ? never : E)>
+	 */
+	#[NoDiscard]
+	public function filterNotNull(): Sequence;
+
+	/**
+	 * Filter elements that are instances of the given class or interface.
+	 *
+	 * @template T
+	 * @param class-string<T> $type
+	 * @return Sequence<T>
+	 */
+	#[NoDiscard]
+	public function filterInstanceOf(string $type): Sequence;
+
+	/**
 	 * Map elements to a new sequence.
 	 * The transform receives the element and optionally the index.
 	 *
@@ -65,6 +83,132 @@ interface Sequence extends IteratorAggregate
 	 */
 	#[NoDiscard]
 	public function map(Closure $transform): Sequence;
+
+	/**
+	 * Transforms each element using the given function and excludes null results.
+	 * Combines map and filterNotNull in a single operation.
+	 *
+	 * @template R
+	 * @param Closure(E, int):(R|null) $transform
+	 * @return Sequence<R>
+	 */
+	#[NoDiscard]
+	public function mapNotNull(Closure $transform): Sequence;
+
+	/**
+	 * Flat map elements to a new sequence.
+	 * Each iterable returned by the transform is consumed lazily, element by element.
+	 *
+	 * @template R
+	 * @param Closure(E, int):iterable<R> $transform
+	 * @return Sequence<R>
+	 */
+	#[NoDiscard]
+	public function flatMap(Closure $transform): Sequence;
+
+	/**
+	 * Flatten a sequence of iterables into a single sequence.
+	 * Iterable elements are flattened one level; non-iterable elements are kept as-is.
+	 * The array{} in value-of keeps the type resolvable when E is never (empty sequences).
+	 *
+	 * @return Sequence<(E is iterable<mixed> ? value-of<E|array{}> : E)>
+	 */
+	#[NoDiscard]
+	public function flatten(): Sequence;
+
+	/**
+	 * Take the first N elements.
+	 * The source is not pulled any further once N elements have been yielded.
+	 *
+	 * @param non-negative-int $n
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function takeFirst(int $n = 1): Sequence;
+
+	/**
+	 * Drops the first N elements.
+	 *
+	 * @param non-negative-int $n
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function dropFirst(int $n = 1): Sequence;
+
+	/**
+	 * Takes elements while the predicate is true.
+	 * The source is not pulled any further once the predicate has returned false.
+	 *
+	 * @param Closure(E, int):bool $predicate
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function takeWhile(Closure $predicate): Sequence;
+
+	/**
+	 * Drops elements while the predicate is true, then returns the rest.
+	 *
+	 * @param Closure(E, int):bool $predicate
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function dropWhile(Closure $predicate): Sequence;
+
+	/**
+	 * Distinct elements by identity.
+	 * Elements already seen during the current pass are skipped, so the memory held grows
+	 * with the number of distinct elements.
+	 *
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function distinct(): Sequence;
+
+	/**
+	 * Distinct elements by selector.
+	 *
+	 * @template K
+	 * @param Closure(E, int):K $selector
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function distinctBy(Closure $selector): Sequence;
+
+	/**
+	 * Combines this sequence with another iterable by pairing elements at the same position.
+	 * The resulting sequence has the length of the shorter input.
+	 *
+	 * @template U
+	 * @param iterable<U> $other
+	 * @return Sequence<array{E, U}>
+	 */
+	#[NoDiscard]
+	public function zip(iterable $other): Sequence;
+
+	/**
+	 * Returns a sequence of pairs of each two adjacent elements in this sequence.
+	 * If the sequence has fewer than two elements, yields nothing.
+	 *
+	 * @return Sequence<array{E, E}>
+	 */
+	#[NoDiscard]
+	public function zipWithNext(): Sequence;
+
+	// --- Iteration ---
+
+	/**
+	 * Returns a sequence applying the given action to each element as it goes through,
+	 * then yielding the element unchanged.
+	 *
+	 * The lazy, chainable counterpart of forEach: the action runs once per element and per
+	 * pass, while the element flows through the pipeline - nothing happens before a
+	 * terminal operation pulls.
+	 *
+	 * @param Closure(E, int):void $action
+	 * @return Sequence<E>
+	 */
+	#[NoDiscard]
+	public function onEach(Closure $action): Sequence;
 
 	// --- Conversion ---
 

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -28,9 +28,9 @@ use NoDiscard;
  *   time - if it fires a SQL query, that query is re-executed on every iteration of
  *   the sequence. It must hand back a fresh iterator on each call; handing back the
  *   iterator of the previous pass (a getIterator() returning a Generator it keeps
- *   around, for instance) throws SequenceAlreadyIteratedException;
+ *   around, for instance) throws NonReplayableSourceException;
  * - a raw Iterator/Generator: the sequence is single-pass and any further iteration
- *   throws SequenceAlreadyIteratedException (a partial pass counts as consumed).
+ *   throws NonReplayableSourceException (a partial pass counts as consumed).
  *
  * Keys are positional: every pass yields fresh 0..n keys, whatever the source yields.
  *

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -178,6 +178,10 @@ interface Sequence extends IteratorAggregate
 	 * Combines this sequence with another iterable by pairing elements at the same position.
 	 * The resulting sequence has the length of the shorter input.
 	 *
+	 * The other side is pulled in lockstep rather than copied, and rewound first just as
+	 * foreach would rewind it: an already started Generator therefore throws. Wrap it in a
+	 * NoRewindIterator to deliberately resume a cursor that is already in flight.
+	 *
 	 * @template U
 	 * @param iterable<U> $other
 	 * @return Sequence<array{E, U}>

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -181,9 +181,10 @@ interface Sequence extends IteratorAggregate
 	 * Combines this sequence with another iterable by pairing elements at the same position.
 	 * The resulting sequence has the length of the shorter input.
 	 *
-	 * The other side is pulled in lockstep rather than copied, and rewound first just as
-	 * foreach would rewind it: an already started Generator therefore throws. Wrap it in a
-	 * NoRewindIterator to deliberately resume a cursor that is already in flight.
+	 * The other side is pulled in lockstep rather than copied. A Generator resumes from its
+	 * current position, so the head of a stream can be consumed before zipping the rest; any
+	 * other iterator is rewound first, and an already advanced one therefore restarts from its
+	 * first element - wrap it in a NoRewindIterator to resume it instead.
 	 *
 	 * @template U
 	 * @param iterable<U> $other

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -11,6 +11,8 @@ namespace Noctud\Collection\Sequence;
 
 use Closure;
 use IteratorAggregate;
+use Noctud\Collection\Exception\InvalidSequenceSourceException;
+use Noctud\Collection\Exception\NonReplayableSourceException;
 use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Set\ImmutableSet;
 use NoDiscard;
@@ -28,7 +30,8 @@ use NoDiscard;
  *   time - if it fires a SQL query, that query is re-executed on every iteration of
  *   the sequence. It must hand back a fresh iterator on each call; handing back the
  *   iterator of the previous pass (a getIterator() returning a Generator it keeps
- *   around, for instance) throws NonReplayableSourceException;
+ *   around, for instance) throws NonReplayableSourceException, and a Closure handing
+ *   back something that is not an iterable throws InvalidSequenceSourceException;
  * - a raw Iterator/Generator: the sequence is single-pass and any further iteration
  *   throws NonReplayableSourceException (a partial pass counts as consumed).
  *
@@ -220,6 +223,8 @@ interface Sequence extends IteratorAggregate
 	 * Convert to an immutable list, consuming one pass of the sequence.
 	 *
 	 * @return ImmutableList<E>
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
 	#[NoDiscard]
 	public function toList(): ImmutableList;
@@ -228,6 +233,8 @@ interface Sequence extends IteratorAggregate
 	 * Convert to an immutable set (duplicates removed), consuming one pass of the sequence.
 	 *
 	 * @return ImmutableSet<E>
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
 	#[NoDiscard]
 	public function toSet(): ImmutableSet;
@@ -236,6 +243,8 @@ interface Sequence extends IteratorAggregate
 	 * Convert to a primitive PHP array, consuming one pass of the sequence.
 	 *
 	 * @return list<E>
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
 	#[NoDiscard]
 	public function toArray(): array;

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -169,11 +169,14 @@ trait SequenceLogic
 	#[NoDiscard]
 	public function zip(iterable $other): Sequence
 	{
-		$otherIsOneShot = $other instanceof Traversable && !$other instanceof IteratorAggregate;
+		// Deciding whether the other side can be walked again belongs next to the cursor() that
+		// rewinds it, or the two classifications drift apart; remembering that a pass already
+		// walked it is sequence-only state and stays here.
+		$otherIsReplayable = ZipOperation::isReplayable($other);
 		$otherConsumed = false;
 
-		return $this->newSequenceOf(function () use ($other, $otherIsOneShot, &$otherConsumed): iterable {
-			if ($otherIsOneShot && $otherConsumed) {
+		return $this->newSequenceOf(function () use ($other, $otherIsReplayable, &$otherConsumed): iterable {
+			if (!$otherIsReplayable && $otherConsumed) {
 				throw NonReplayableSourceException::zippedIterableAlreadyIterated();
 			}
 

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -15,8 +15,15 @@ use IteratorAggregate;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
 use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
 use Noctud\Collection\List\ImmutableList;
+use Noctud\Collection\Operation\DistinctOperation;
+use Noctud\Collection\Operation\DropOperation;
 use Noctud\Collection\Operation\FilterOperation;
+use Noctud\Collection\Operation\FlatMapKeyValueOperation;
+use Noctud\Collection\Operation\FlattenOperation;
 use Noctud\Collection\Operation\MapKeyValueOperation;
+use Noctud\Collection\Operation\TakeOperation;
+use Noctud\Collection\Operation\ZipOperation;
+use Noctud\Collection\Operation\ZipWithNextOperation;
 use Noctud\Collection\Set\ImmutableSet;
 use NoDiscard;
 use Traversable;
@@ -61,11 +68,31 @@ trait SequenceLogic
 		})();
 	}
 
+	// --- Transformation ---
+
 	/** {@inheritDoc} */
 	#[NoDiscard]
 	public function filter(Closure $predicate): Sequence
 	{
 		return $this->newSequenceOf(fn (): iterable => new FilterOperation($this)->byPredicate($predicate));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return Sequence<(E is null ? never : E)>
+	 */
+	#[NoDiscard] // @phpstan-ignore conditionalType.subjectNotFound (in classes with a concrete E the conditional subject is already substituted)
+	public function filterNotNull(): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new FilterOperation($this)->notNullValues());
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function filterInstanceOf(string $type): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new FilterOperation($this)->byValue(fn ($v) => $v instanceof $type)); // @phpstan-ignore return.type
 	}
 
 	/** {@inheritDoc} */
@@ -74,6 +101,109 @@ trait SequenceLogic
 	{
 		return $this->newSequenceOf(fn (): iterable => new MapKeyValueOperation($this)->items($transform));
 	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function mapNotNull(Closure $transform): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new MapKeyValueOperation($this)->itemsNotNull($transform));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function flatMap(Closure $transform): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new FlatMapKeyValueOperation($this)->items($transform));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function flatten(): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new FlattenOperation($this)->items());
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function takeFirst(int $n = 1): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new TakeOperation($this)->first($n));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function dropFirst(int $n = 1): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new DropOperation($this)->first($n));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function takeWhile(Closure $predicate): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new TakeOperation($this)->byPredicate($predicate));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function dropWhile(Closure $predicate): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new DropOperation($this)->byPredicate($predicate));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function distinct(): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new DistinctOperation($this)->items());
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function distinctBy(Closure $selector): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new DistinctOperation($this)->bySelector($selector));
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function zip(iterable $other): Sequence
+	{
+		$otherIsOneShot = $other instanceof Traversable && !$other instanceof IteratorAggregate;
+		$otherConsumed = false;
+
+		return $this->newSequenceOf(function () use ($other, $otherIsOneShot, &$otherConsumed): iterable {
+			if ($otherIsOneShot && $otherConsumed) {
+				throw SequenceAlreadyIteratedException::nonReplayableSourceAlreadyIterated();
+			}
+
+			$otherConsumed = true;
+
+			return new ZipOperation($this)->with($other);
+		});
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function zipWithNext(): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new ZipWithNextOperation($this)->pairs());
+	}
+
+	// --- Iteration ---
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function onEach(Closure $action): Sequence
+	{
+		return $this->newSequenceOf(fn (): iterable => new MapKeyValueOperation($this)->items(function ($v, $k) use ($action) {
+			$action($v, $k);
+
+			return $v;
+		}));
+	}
+
+	// --- Conversion ---
 
 	/** {@inheritDoc} */
 	#[NoDiscard]

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -177,9 +177,16 @@ trait SequenceLogic
 				throw SequenceAlreadyIteratedException::nonReplayableSourceAlreadyIterated();
 			}
 
-			$otherConsumed = true;
+			// Marked per pair rather than per pass: a pass that pairs nothing never positions
+			// the other side, which stays where it was and replayable - so it must not be
+			// counted as consumed.
+			return (function () use ($other, &$otherConsumed): Generator {
+				foreach (new ZipOperation($this)->with($other) as $pair) {
+					$otherConsumed = true;
 
-			return new ZipOperation($this)->with($other);
+					yield $pair;
+				}
+			})();
 		});
 	}
 

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -13,7 +13,7 @@ use Closure;
 use Generator;
 use IteratorAggregate;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
-use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\Exception\NonReplayableSourceException;
 use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Operation\DistinctOperation;
 use Noctud\Collection\Operation\DropOperation;
@@ -174,7 +174,7 @@ trait SequenceLogic
 
 		return $this->newSequenceOf(function () use ($other, $otherIsOneShot, &$otherConsumed): iterable {
 			if ($otherIsOneShot && $otherConsumed) {
-				throw SequenceAlreadyIteratedException::nonReplayableSourceAlreadyIterated();
+				throw NonReplayableSourceException::zippedIterableAlreadyIterated();
 			}
 
 			// Marked per pair rather than per pass: a pass that pairs nothing never positions
@@ -282,7 +282,7 @@ trait SequenceLogic
 		}
 
 		if ($this->consumed) {
-			throw SequenceAlreadyIteratedException::nonReplayableSourceAlreadyIterated();
+			throw NonReplayableSourceException::sequenceSourceAlreadyIterated();
 		}
 
 		$this->consumed = true;
@@ -309,7 +309,7 @@ trait SequenceLogic
 		// a producer, re-invoked per pass by the foreach that unwraps it.
 		if ($produced instanceof Traversable && !$produced instanceof IteratorAggregate) {
 			if ($this->lastProduced?->get() === $produced) {
-				throw SequenceAlreadyIteratedException::sourceReturnedSameIterator();
+				throw NonReplayableSourceException::sourceReturnedSameIterator();
 			}
 
 			$this->lastProduced = WeakReference::create($produced);

--- a/src/Set/SetLogic.php
+++ b/src/Set/SetLogic.php
@@ -178,10 +178,7 @@ trait SetLogic
 	#[NoDiscard]
 	public function takeWhile(Closure $predicate): ImmutableSet
 	{
-		$i = 0;
-		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new TakeOperation($this->store)->byPredicate($predicate));
 	}
 
 	/**
@@ -192,10 +189,7 @@ trait SetLogic
 	#[NoDiscard]
 	public function dropWhile(Closure $predicate): ImmutableSet
 	{
-		$i = 0;
-		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate(function ($v) use ($predicate, &$i) {
-			return $predicate($v, $i++);
-		}));
+		return $this->newCollectionOf(new DropOperation($this->store)->byPredicate($predicate));
 	}
 
 	/**

--- a/tests/Collection/CollectionGroupAndZip.php
+++ b/tests/Collection/CollectionGroupAndZip.php
@@ -14,6 +14,7 @@ use Generator;
 use LimitIterator;
 use Noctud\Collection\Exception\UnsupportedOperationException;
 use Noctud\Collection\Map\ImmutableMap;
+use NoRewindIterator;
 use PHPUnit\Framework\Attributes\Test;
 use SplStack;
 
@@ -164,6 +165,50 @@ trait CollectionGroupAndZip
 		$collection = $this->collectionOf([1, 2]);
 
 		$this->assertSame([[1, 'a'], [2, 'b']], $collection->zip($other)->toArray());
+	}
+
+	#[Test]
+	public function zip_with_a_started_generator(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+			yield 'c';
+		})();
+		$other->current();
+		$other->next();
+
+		$collection = $this->collectionOf([1, 2]);
+
+		// A Generator is never rewound: it is always positioned, so it resumes from where it
+		// stands and the head of a stream can be consumed before zipping the rest.
+		$this->assertSame([[1, 'b'], [2, 'c']], $collection->zip($other)->toArray());
+	}
+
+	#[Test]
+	public function zip_with_an_advanced_iterator(): void
+	{
+		$other = new ArrayIterator(['a', 'b', 'c']);
+		$other->next();
+
+		$collection = $this->collectionOf([1, 2]);
+
+		// The flip side of rewinding everything that is not a Generator: an advanced cursor
+		// cannot be told apart from a fresh one, so it restarts rather than resuming.
+		$this->assertSame([[1, 'a'], [2, 'b']], $collection->zip($other)->toArray());
+	}
+
+	#[Test]
+	public function zip_with_an_advanced_iterator_wrapped_in_a_no_rewind_iterator(): void
+	{
+		$other = new ArrayIterator(['a', 'b', 'c']);
+		$other->next();
+
+		$collection = $this->collectionOf([1, 2]);
+
+		// NoRewindIterator::rewind() is a no-op, which is how a caller who does mean to resume
+		// a non-Generator cursor says so: only they can know that it is mid-stream.
+		$this->assertSame([[1, 'b'], [2, 'c']], $collection->zip(new NoRewindIterator($other))->toArray());
 	}
 
 	#[Test]

--- a/tests/Collection/CollectionGroupAndZip.php
+++ b/tests/Collection/CollectionGroupAndZip.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Tests\Collection;
 
+use ArrayIterator;
 use Generator;
+use LimitIterator;
 use Noctud\Collection\Exception\UnsupportedOperationException;
 use Noctud\Collection\Map\ImmutableMap;
 use PHPUnit\Framework\Attributes\Test;
+use SplStack;
 
 trait CollectionGroupAndZip
 {
@@ -134,6 +137,33 @@ trait CollectionGroupAndZip
 		// The other side is walked in lockstep, never buffered - and not pulled once past the
 		// shorter side either.
 		$this->assertSame(['a', 'b'], $pulled);
+	}
+
+	#[Test]
+	public function zip_with_an_unpositioned_iterator(): void
+	{
+		$stack = new SplStack();
+		$stack->push('a');
+		$stack->push('b');
+
+		// An SplDoublyLinkedList holds no position until it is rewound, so valid() answers
+		// false on a stack that plainly has elements. Left unrewound, zip reads that as an
+		// empty side and pairs nothing at all.
+		$this->assertCount(2, $stack);
+		$this->assertSame(['b', 'a'], iterator_to_array($stack, false));
+
+		$collection = $this->collectionOf([1, 2]);
+
+		$this->assertSame([[1, 'b'], [2, 'a']], $collection->zip($stack)->toArray());
+	}
+
+	#[Test]
+	public function zip_with_an_iterator_decorator(): void
+	{
+		$other = new LimitIterator(new ArrayIterator(['a', 'b', 'c']), 0, 2);
+		$collection = $this->collectionOf([1, 2]);
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $collection->zip($other)->toArray());
 	}
 
 	#[Test]

--- a/tests/Collection/CollectionGroupAndZip.php
+++ b/tests/Collection/CollectionGroupAndZip.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Tests\Collection;
 
+use Generator;
 use Noctud\Collection\Exception\UnsupportedOperationException;
 use Noctud\Collection\Map\ImmutableMap;
 use PHPUnit\Framework\Attributes\Test;
@@ -112,6 +113,27 @@ trait CollectionGroupAndZip
 	{
 		$collection = $this->collectionOf([]);
 		$this->assertSame([], $collection->zip(['a'])->toArray());
+	}
+
+	#[Test]
+	public function zip_pulls_the_other_iterable_lazily(): void
+	{
+		$pulled = [];
+		$other = (static function () use (&$pulled): Generator {
+			foreach (['a', 'b', 'c', 'd'] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		})();
+
+		$collection = $this->collectionOf([1, 2]);
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $collection->zip($other)->toArray());
+
+		// The other side is walked in lockstep, never buffered - and not pulled once past the
+		// shorter side either.
+		$this->assertSame(['a', 'b'], $pulled);
 	}
 
 	#[Test]

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -18,6 +18,7 @@ use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Sequence\GeneratorSequence;
 use Noctud\Collection\Tests\Sequence\Fixture\GeneratorAggregate;
 use Noctud\Collection\Tests\Sequence\Fixture\SharedIteratorAggregate;
+use NoRewindIterator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use WeakReference;
@@ -94,8 +95,8 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -199,8 +200,8 @@ final class SequenceIterationTest extends TestCase
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
 		);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -217,8 +218,47 @@ final class SequenceIterationTest extends TestCase
 		// The other side is a producer here, so its own guard is the one that fires.
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
+	}
+
+	#[Test]
+	public function zip_against_an_already_started_generator_throws(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+			yield 'c';
+		})();
+		$other->current();
+		$other->next();
+
+		// The other side is positioned like foreach positions it, so a cursor already in
+		// flight is refused rather than silently resumed - the same answer sequenceOf() gives
+		// to a started generator.
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageIsOrContains('Cannot rewind a generator that was already run');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([1, 2])->zip($other)->toArray();
+	}
+
+	#[Test]
+	public function zip_resumes_a_started_cursor_wrapped_in_a_no_rewind_iterator(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+			yield 'c';
+		})();
+		$other->current();
+		$other->next();
+
+		// NoRewindIterator::rewind() is a no-op, which is how a caller who does mean to resume
+		// a cursor in flight says so: only they can know that it is mid-stream.
+		$sequence = sequenceOf([1, 2])->zip(new NoRewindIterator($other));
+
+		$this->assertSame([[1, 'b'], [2, 'c']], $sequence->toArray());
 	}
 
 	#[Test]
@@ -249,8 +289,8 @@ final class SequenceIterationTest extends TestCase
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
 		);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -262,8 +302,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -285,8 +325,8 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -305,8 +345,8 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -329,8 +369,8 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessageIsOrContains('Cannot traverse an already closed generator');
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -342,8 +382,8 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(InvalidSequenceSourceException::class);
 		$this->expectExceptionMessageIsOrContains('The sequence\'s source closure must return an iterable, got int.');
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -360,8 +400,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -385,8 +425,8 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 
 	#[Test]
@@ -401,7 +441,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
-        $_ = $sequence->toArray();
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->toArray();
 	}
 }

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -13,7 +13,7 @@ use ArrayIterator;
 use Exception;
 use Generator;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
-use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\Exception\NonReplayableSourceException;
 use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Sequence\GeneratorSequence;
 use Noctud\Collection\Tests\Sequence\Fixture\GeneratorAggregate;
@@ -90,7 +90,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
@@ -226,9 +226,10 @@ final class SequenceIterationTest extends TestCase
 
 		// Without the guard the other side would resume where it stopped and the second pass
 		// would silently pair 1 with 'c' - the failure mode the contract exists to prevent.
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		// The message names the zipped iterable, not this sequence, which is replayable here.
+		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
-			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
+			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate - a collection or a sequence, for instance - to iterate the result more than once.',
 		);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
@@ -247,7 +248,7 @@ final class SequenceIterationTest extends TestCase
 		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
 
 		// The other side is a producer here, so its own guard is the one that fires.
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();
@@ -315,7 +316,7 @@ final class SequenceIterationTest extends TestCase
 
 		self::assertSame([1], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
 		);
@@ -331,7 +332,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1, 2], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();
@@ -351,7 +352,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
@@ -371,7 +372,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
@@ -429,7 +430,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame([1, 2], $sequence->toSet()->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();
@@ -454,7 +455,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->assertSame(1, $first);
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();
@@ -470,7 +471,7 @@ final class SequenceIterationTest extends TestCase
 
 		$sequence->getIterator();
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -143,6 +143,85 @@ final class SequenceIterationTest extends TestCase
 	}
 
 	#[Test]
+	public function replayed_pass_starts_from_fresh_intermediate_state(): void
+	{
+		// distinct's seen-set, dropWhile's dropping flag, dropFirst's counter and
+		// zipWithNext's previous element are all built inside the factory closure, so the
+		// second pass rebuilds them instead of resuming where the first one stopped.
+		$sequence = sequenceOf([1, 1, 2, 3, 3, 4])
+			->distinct()
+			->dropWhile(static fn (int $v): bool => $v < 2)
+			->dropFirst()
+			->zipWithNext();
+
+		$this->assertSame([[3, 4]], $sequence->toArray());
+		$this->assertSame([[3, 4]], $sequence->toArray());
+	}
+
+	#[Test]
+	public function replayed_pass_restarts_the_positional_counters(): void
+	{
+		$taking = sequenceOf(['a', 'b', 'c'])->takeWhile(static fn (string $v, int $i): bool => $i < 2);
+		$dropping = sequenceOf(['a', 'b', 'c'])->dropWhile(static fn (string $v, int $i): bool => $i < 2);
+
+		$this->assertSame(['a', 'b'], $taking->toArray());
+		$this->assertSame(['a', 'b'], $taking->toArray());
+
+		$this->assertSame(['c'], $dropping->toArray());
+		$this->assertSame(['c'], $dropping->toArray());
+	}
+
+	#[Test]
+	public function zip_replays_when_both_sides_are_replayable(): void
+	{
+		$sequence = sequenceOf([1, 2, 3])->zip(['a', 'b']);
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+	}
+
+	#[Test]
+	public function zip_against_a_raw_iterator_throws_on_second_pass(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+			yield 'c';
+		})();
+		$sequence = sequenceOf([1, 2])->zip($other);
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+
+		// Without the guard the other side would resume where it stopped and the second pass
+		// would silently pair 1 with 'c' - the failure mode the contract exists to prevent.
+		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectExceptionMessageIsOrContains(
+			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
+		);
+
+        // phpcs:ignore
+        $_ = $sequence->toArray();
+	}
+
+	#[Test]
+	public function zip_against_a_one_shot_sequence_throws_on_second_pass(): void
+	{
+		$generator = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+		})();
+		$sequence = sequenceOf([1, 2])->zip(sequenceOf($generator));
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+
+		// The other side is a producer here, so its own guard is the one that fires.
+		$this->expectException(SequenceAlreadyIteratedException::class);
+
+        // phpcs:ignore
+        $_ = $sequence->toArray();
+	}
+
+	#[Test]
 	public function replay_sees_live_collection_mutations(): void
 	{
 		$list = mutableListOf([1, 2]);

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -182,6 +182,37 @@ final class SequenceIterationTest extends TestCase
 	}
 
 	#[Test]
+	public function zip_replays_when_a_pass_paired_nothing(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+		})();
+		$sequence = sequenceOf([])->zip($other);
+
+		$this->assertSame([], $sequence->toArray());
+
+		// Pairing nothing left the other side where it was, so the one-shot guard has nothing
+		// to complain about: it counts a consumed cursor, not an attempted pass.
+		$this->assertSame([], $sequence->toArray());
+		$this->assertSame('a', $other->current());
+	}
+
+	#[Test]
+	public function zip_replays_when_this_side_was_emptied_by_a_previous_stage(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+		})();
+		$sequence = sequenceOf([1, 2])->takeFirst(0)->zip($other);
+
+		$this->assertSame([], $sequence->toArray());
+		$this->assertSame([], $sequence->toArray());
+		$this->assertSame('a', $other->current());
+	}
+
+	#[Test]
 	public function zip_against_a_raw_iterator_throws_on_second_pass(): void
 	{
 		$other = (static function (): Generator {

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -95,8 +95,7 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -232,8 +231,7 @@ final class SequenceIterationTest extends TestCase
 			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate - a collection or a sequence, for instance - to iterate the result more than once.',
 		);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -250,12 +248,11 @@ final class SequenceIterationTest extends TestCase
 		// The other side is a producer here, so its own guard is the one that fires.
 		$this->expectException(NonReplayableSourceException::class);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
-	public function zip_against_an_already_started_generator_throws(): void
+	public function zip_resumes_an_already_started_generator(): void
 	{
 		$other = (static function (): Generator {
 			yield 'a';
@@ -265,29 +262,31 @@ final class SequenceIterationTest extends TestCase
 		$other->current();
 		$other->next();
 
-		// The other side is positioned like foreach positions it, so a cursor already in
-		// flight is refused rather than silently resumed - the same answer sequenceOf() gives
-		// to a started generator.
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessageIsOrContains('Cannot rewind a generator that was already run');
-
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = sequenceOf([1, 2])->zip($other)->toArray();
+		// A Generator is never rewound: it is always positioned, so valid() === false means
+		// exhausted and not "not started". Consuming the head of a stream and zipping the rest
+		// is therefore supported, as it is in Kotlin.
+		$this->assertSame([[1, 'b'], [2, 'c']], sequenceOf([1, 2])->zip($other)->toArray());
 	}
 
 	#[Test]
-	public function zip_resumes_a_started_cursor_wrapped_in_a_no_rewind_iterator(): void
+	public function zip_restarts_an_already_advanced_iterator(): void
 	{
-		$other = (static function (): Generator {
-			yield 'a';
-			yield 'b';
-			yield 'c';
-		})();
-		$other->current();
+		$other = new ArrayIterator(['a', 'b', 'c']);
+		$other->next();
+
+		// The flip side of rewinding everything that is not a Generator: an advanced cursor
+		// cannot be told apart from a fresh one, so it restarts rather than resuming.
+		$this->assertSame([[1, 'a'], [2, 'b']], sequenceOf([1, 2])->zip($other)->toArray());
+	}
+
+	#[Test]
+	public function zip_resumes_an_advanced_iterator_wrapped_in_a_no_rewind_iterator(): void
+	{
+		$other = new ArrayIterator(['a', 'b', 'c']);
 		$other->next();
 
 		// NoRewindIterator::rewind() is a no-op, which is how a caller who does mean to resume
-		// a cursor in flight says so: only they can know that it is mid-stream.
+		// a non-Generator cursor says so: only they can know that it is mid-stream.
 		$sequence = sequenceOf([1, 2])->zip(new NoRewindIterator($other));
 
 		$this->assertSame([[1, 'b'], [2, 'c']], $sequence->toArray());
@@ -321,8 +320,7 @@ final class SequenceIterationTest extends TestCase
 			'This sequence is backed by a non-replayable source and has already been iterated. Create a new sequence from a fresh source to iterate again.',
 		);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -334,8 +332,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(NonReplayableSourceException::class);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -357,8 +354,7 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -377,8 +373,7 @@ final class SequenceIterationTest extends TestCase
 			'The sequence\'s source returned the same iterator instance again - a source closure or an IteratorAggregate must produce a fresh iterator on each pass.',
 		);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -401,8 +396,7 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessageIsOrContains('Cannot traverse an already closed generator');
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -414,8 +408,7 @@ final class SequenceIterationTest extends TestCase
 		$this->expectException(InvalidSequenceSourceException::class);
 		$this->expectExceptionMessageIsOrContains('The sequence\'s source closure must return an iterable, got int.');
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -432,8 +425,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(NonReplayableSourceException::class);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -457,8 +449,7 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(NonReplayableSourceException::class);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]
@@ -473,7 +464,6 @@ final class SequenceIterationTest extends TestCase
 
 		$this->expectException(NonReplayableSourceException::class);
 
-        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
-		$_ = $sequence->toArray();
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 }

--- a/tests/Sequence/SequenceIterationTest.php
+++ b/tests/Sequence/SequenceIterationTest.php
@@ -21,6 +21,7 @@ use Noctud\Collection\Tests\Sequence\Fixture\SharedIteratorAggregate;
 use NoRewindIterator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use SplStack;
 use WeakReference;
 use function Noctud\Collection\listOf;
 use function Noctud\Collection\mutableListOf;
@@ -181,6 +182,59 @@ final class SequenceIterationTest extends TestCase
 	}
 
 	#[Test]
+	public function zip_replays_over_an_iterator_the_lockstep_rewinds(): void
+	{
+		// Replayability is read off what cursor() does: these are rewound, so a second pass
+		// starts them over. Classifying every raw Iterator as one-shot used to refuse this.
+		$sequence = sequenceOf([1, 2])->zip(new ArrayIterator(['a', 'b']));
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+
+		$stack = new SplStack();
+		$stack->push('a');
+		$stack->push('b');
+		$overStack = sequenceOf([1, 2])->zip($stack);
+
+		$this->assertSame([[1, 'b'], [2, 'a']], $overStack->toArray());
+		$this->assertSame([[1, 'b'], [2, 'a']], $overStack->toArray());
+	}
+
+	#[Test]
+	public function zip_against_a_no_rewind_iterator_throws_on_second_pass(): void
+	{
+		$sequence = sequenceOf([1, 2])->zip(new NoRewindIterator(new ArrayIterator(['a', 'b', 'c', 'd'])));
+
+		$this->assertSame([[1, 'a'], [2, 'b']], $sequence->toArray());
+
+		// It swallows the rewind, so a second pass would resume at 'c' rather than start over.
+		$this->expectException(NonReplayableSourceException::class);
+
+		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+	}
+
+	#[Test]
+	public function zip_reports_an_other_side_that_cannot_be_rewound(): void
+	{
+		$started = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+		})();
+		$started->current();
+		$started->next();
+
+		// An aggregate handing back a cursor already in flight: the rewind fails, and PHP's own
+		// "Cannot rewind a generator that was already run" is relabelled rather than leaked.
+		try {
+			$_ = sequenceOf([1, 2])->zip(new SharedIteratorAggregate($started))->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+			$this->fail('Expected the failed rewind to be reported.');
+		} catch (NonReplayableSourceException $e) {
+			$this->assertStringContainsString('could not be rewound', $e->getMessage());
+			$this->assertInstanceOf(Exception::class, $e->getPrevious());
+		}
+	}
+
+	#[Test]
 	public function zip_replays_when_a_pass_paired_nothing(): void
 	{
 		$other = (static function (): Generator {
@@ -228,7 +282,7 @@ final class SequenceIterationTest extends TestCase
 		// The message names the zipped iterable, not this sequence, which is replayable here.
 		$this->expectException(NonReplayableSourceException::class);
 		$this->expectExceptionMessageIsOrContains(
-			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate - a collection or a sequence, for instance - to iterate the result more than once.',
+			'The iterable passed to zip() is a non-replayable cursor and has already been consumed. Zip an array or an IteratorAggregate to iterate the result more than once.',
 		);
 
 		$_ = $sequence->toArray(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable

--- a/tests/Sequence/SequenceLazinessTest.php
+++ b/tests/Sequence/SequenceLazinessTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Noctud\Collection\Tests\Sequence;
 
 use Generator;
-use Noctud\Collection\Exception\SequenceAlreadyIteratedException;
+use Noctud\Collection\Exception\NonReplayableSourceException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function Noctud\Collection\sequenceOf;
@@ -209,7 +209,7 @@ final class SequenceLazinessTest extends TestCase
 
 		$this->assertSame([10, 20], $sequence->toArray());
 
-		$this->expectException(SequenceAlreadyIteratedException::class);
+		$this->expectException(NonReplayableSourceException::class);
 
         // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();

--- a/tests/Sequence/SequenceLazinessTest.php
+++ b/tests/Sequence/SequenceLazinessTest.php
@@ -167,6 +167,25 @@ final class SequenceLazinessTest extends TestCase
 	}
 
 	#[Test]
+	public function zip_does_not_pull_the_other_side_when_this_one_is_empty(): void
+	{
+		$pulled = [];
+		$other = (static function () use (&$pulled): Generator {
+			foreach (['a', 'b'] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		})();
+
+		$this->assertSame([], sequenceOf([])->zip($other)->toArray());
+
+		// The other side is only positioned once this one is known to hold an element, so an
+		// empty side spares it even the single pull that positioning costs.
+		$this->assertSame([], $pulled);
+	}
+
+	#[Test]
 	public function chained_pipeline_replays_through_replayable_root(): void
 	{
 		$sequence = sequenceOf([1, 2, 3])
@@ -192,7 +211,7 @@ final class SequenceLazinessTest extends TestCase
 
 		$this->expectException(SequenceAlreadyIteratedException::class);
 
-        // phpcs:ignore
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 		$_ = $sequence->toArray();
 	}
 }

--- a/tests/Sequence/SequenceLazinessTest.php
+++ b/tests/Sequence/SequenceLazinessTest.php
@@ -77,6 +77,96 @@ final class SequenceLazinessTest extends TestCase
 	}
 
 	#[Test]
+	public function onEach_is_lazy_and_observes_the_values_of_its_own_stage(): void
+	{
+		$log = [];
+		$sequence = sequenceOf([1, 2, 3])
+			->onEach(static function (int $v) use (&$log): void {
+				$log[] = "a:$v";
+			})
+			->map(static fn (int $v): int => $v * 10)
+			->onEach(static function (int $v) use (&$log): void {
+				$log[] = "b:$v";
+			});
+
+		$this->assertSame([], $log);
+
+		$this->assertSame([10, 20, 30], $sequence->toArray());
+		$this->assertSame(['a:1', 'b:10', 'a:2', 'b:20', 'a:3', 'b:30'], $log);
+	}
+
+	#[Test]
+	public function takeFirst_pulls_exactly_n_elements_from_the_source(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3, 4, 5] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		$this->assertSame([1, 2], $sequence->takeFirst(2)->toArray());
+		$this->assertSame([1, 2], $pulled);
+	}
+
+	#[Test]
+	public function takeFirst_only_maps_what_it_takes(): void
+	{
+		$transformCalls = 0;
+
+		$result = sequenceOf([1, 2, 3, 4, 5])
+			->map(static function (int $v) use (&$transformCalls): int {
+				$transformCalls++;
+
+				return $v * 10;
+			})
+			->takeFirst(2)
+			->toArray();
+
+		$this->assertSame([10, 20], $result);
+		$this->assertSame(2, $transformCalls);
+	}
+
+	#[Test]
+	public function takeWhile_stops_pulling_at_the_first_failing_element(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3, 4, 5] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		$this->assertSame([1, 2], $sequence->takeWhile(static fn (int $v): bool => $v < 3)->toArray());
+
+		// 3 is pulled and tested, then nothing further: the predicate has to see the element
+		// that ends the run.
+		$this->assertSame([1, 2, 3], $pulled);
+	}
+
+	#[Test]
+	public function zip_pulls_the_other_side_lazily(): void
+	{
+		$pulled = [];
+		$other = (static function () use (&$pulled): Generator {
+			foreach (['a', 'b', 'c', 'd'] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		})();
+
+		$this->assertSame([[1, 'a'], [2, 'b']], sequenceOf([1, 2])->zip($other)->toArray());
+
+		// Never buffered, and not pulled once past the shorter side either.
+		$this->assertSame(['a', 'b'], $pulled);
+	}
+
+	#[Test]
 	public function chained_pipeline_replays_through_replayable_root(): void
 	{
 		$sequence = sequenceOf([1, 2, 3])

--- a/tests/Sequence/SequenceTransformTest.php
+++ b/tests/Sequence/SequenceTransformTest.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Tests\Sequence;
 
+use ArrayIterator;
 use Generator;
+use LimitIterator;
 use Noctud\Collection\Tests\Collection\Fixture\Cat;
 use Noctud\Collection\Tests\Collection\Fixture\Dog;
 use Noctud\Collection\Tests\Collection\Fixture\Walkable;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use SplStack;
 use function Noctud\Collection\listOf;
 use function Noctud\Collection\sequenceOf;
 
@@ -318,6 +321,28 @@ final class SequenceTransformTest extends TestCase
 
 		$this->assertSame([[1, 'a'], [2, 'b']], sequenceOf([1, 2, 3])->zip($other)->toArray());
 		$this->assertSame([[1, 'a']], sequenceOf([1, 2])->zip(sequenceOf(['a']))->toArray());
+	}
+
+	#[Test]
+	public function zip_positions_an_unrewound_iterator_on_the_other_side(): void
+	{
+		$stack = new SplStack();
+		$stack->push('a');
+		$stack->push('b');
+
+		// valid() answers false on a stack that has never been rewound, however many elements
+		// it holds: without positioning it, lockstep would read an empty side and pair nothing.
+		$this->assertCount(2, $stack);
+
+		$this->assertSame([[1, 'b'], [2, 'a']], sequenceOf([1, 2])->zip($stack)->toArray());
+	}
+
+	#[Test]
+	public function zip_positions_an_iterator_decorator_on_the_other_side(): void
+	{
+		$other = new LimitIterator(new ArrayIterator(['a', 'b', 'c']), 0, 2);
+
+		$this->assertSame([[1, 'a'], [2, 'b']], sequenceOf([1, 2])->zip($other)->toArray());
 	}
 
 	#[Test]

--- a/tests/Sequence/SequenceTransformTest.php
+++ b/tests/Sequence/SequenceTransformTest.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Tests\Sequence;
 
+use Generator;
+use Noctud\Collection\Tests\Collection\Fixture\Cat;
+use Noctud\Collection\Tests\Collection\Fixture\Dog;
+use Noctud\Collection\Tests\Collection\Fixture\Walkable;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use function Noctud\Collection\listOf;
@@ -31,6 +35,43 @@ final class SequenceTransformTest extends TestCase
 		$this->assertSame(
 			listOf($data)->filter($predicate)->toArray(),
 			sequenceOf($data)->filter($predicate)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function filterNotNull_drops_null_elements(): void
+	{
+		$this->assertSame([1, 2], sequenceOf([1, null, 2, null])->filterNotNull()->toArray());
+	}
+
+	#[Test]
+	public function filterNotNull_matches_its_collection_counterpart(): void
+	{
+		$data = [null, 1, null, 2];
+
+		$this->assertSame(
+			listOf($data)->filterNotNull()->toArray(),
+			sequenceOf($data)->filterNotNull()->toArray(),
+		);
+	}
+
+	#[Test]
+	public function filterInstanceOf_keeps_only_instances_of_the_given_type(): void
+	{
+		$dog = new Dog('Rex');
+		$cat = new Cat('Felix');
+
+		$this->assertSame([$dog], sequenceOf([$dog, $cat])->filterInstanceOf(Walkable::class)->toArray());
+	}
+
+	#[Test]
+	public function filterInstanceOf_matches_its_collection_counterpart(): void
+	{
+		$data = [new Dog('Rex'), new Cat('Felix'), new Dog('Bobby')];
+
+		$this->assertSame(
+			listOf($data)->filterInstanceOf(Walkable::class)->toArray(),
+			sequenceOf($data)->filterInstanceOf(Walkable::class)->toArray(),
 		);
 	}
 
@@ -58,6 +99,276 @@ final class SequenceTransformTest extends TestCase
 	}
 
 	#[Test]
+	public function mapNotNull_drops_the_elements_the_transform_maps_to_null(): void
+	{
+		$this->assertSame(
+			[20, 40],
+			sequenceOf([1, 2, 3, 4])
+				->mapNotNull(static fn (int $v): ?int => $v % 2 === 0 ? $v * 10 : null)
+				->toArray(),
+		);
+	}
+
+	#[Test]
+	public function mapNotNull_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3, 4, 5];
+		$transform = static fn (int $v): ?string => $v > 2 ? "#$v" : null;
+
+		$this->assertSame(
+			listOf($data)->mapNotNull($transform)->toArray(),
+			sequenceOf($data)->mapNotNull($transform)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function flatMap_concatenates_the_iterables_returned_by_the_transform(): void
+	{
+		$this->assertSame(
+			[1, 10, 2, 20],
+			sequenceOf([1, 2])->flatMap(static fn (int $v): array => [$v, $v * 10])->toArray(),
+		);
+	}
+
+	#[Test]
+	public function flatMap_matches_its_collection_counterpart(): void
+	{
+		$data = ['ab', 'c'];
+		$transform = static fn (string $v): array => str_split($v);
+
+		$this->assertSame(
+			listOf($data)->flatMap($transform)->toArray(),
+			sequenceOf($data)->flatMap($transform)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function flatMap_accepts_a_generator_returning_transform(): void
+	{
+		$result = sequenceOf([1, 2])
+			->flatMap(static function (int $v): Generator {
+				yield $v;
+				yield -$v;
+			})
+			->toArray();
+
+		$this->assertSame([1, -1, 2, -2], $result);
+	}
+
+	#[Test]
+	public function flatten_unwraps_one_level_and_keeps_non_iterable_elements(): void
+	{
+		$this->assertSame([1, 2, 3, 4], sequenceOf([[1, 2], [3], 4])->flatten()->toArray());
+	}
+
+	#[Test]
+	public function flatten_matches_its_collection_counterpart(): void
+	{
+		$data = [[1, 2], [], [3], 4];
+
+		$this->assertSame(
+			listOf($data)->flatten()->toArray(),
+			sequenceOf($data)->flatten()->toArray(),
+		);
+	}
+
+	#[Test]
+	public function takeFirst_keeps_the_first_n_elements(): void
+	{
+		$this->assertSame([1, 2], sequenceOf([1, 2, 3, 4])->takeFirst(2)->toArray());
+	}
+
+	#[Test]
+	public function takeFirst_defaults_to_one_element_and_accepts_zero(): void
+	{
+		$this->assertSame([1], sequenceOf([1, 2, 3])->takeFirst()->toArray());
+		$this->assertSame([], sequenceOf([1, 2, 3])->takeFirst(0)->toArray());
+	}
+
+	#[Test]
+	public function takeFirst_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3];
+
+		foreach ([0, 1, 2, 3, 10] as $n) {
+			$this->assertSame(
+				listOf($data)->takeFirst($n)->toArray(),
+				sequenceOf($data)->takeFirst($n)->toArray(),
+			);
+		}
+	}
+
+	#[Test]
+	public function dropFirst_skips_the_first_n_elements(): void
+	{
+		$this->assertSame([3, 4], sequenceOf([1, 2, 3, 4])->dropFirst(2)->toArray());
+	}
+
+	#[Test]
+	public function dropFirst_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3];
+
+		foreach ([0, 1, 2, 3, 10] as $n) {
+			$this->assertSame(
+				listOf($data)->dropFirst($n)->toArray(),
+				sequenceOf($data)->dropFirst($n)->toArray(),
+			);
+		}
+	}
+
+	#[Test]
+	public function takeWhile_stops_at_the_first_element_failing_the_predicate(): void
+	{
+		$this->assertSame([1, 2], sequenceOf([1, 2, 3, 1])->takeWhile(static fn (int $v): bool => $v < 3)->toArray());
+	}
+
+	#[Test]
+	public function takeWhile_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3, 1];
+		$predicate = static fn (int $v): bool => $v < 3;
+
+		$this->assertSame(
+			listOf($data)->takeWhile($predicate)->toArray(),
+			sequenceOf($data)->takeWhile($predicate)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function dropWhile_yields_everything_from_the_first_element_failing_the_predicate(): void
+	{
+		$this->assertSame([3, 1], sequenceOf([1, 2, 3, 1])->dropWhile(static fn (int $v): bool => $v < 3)->toArray());
+	}
+
+	#[Test]
+	public function dropWhile_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3, 1];
+		$predicate = static fn (int $v): bool => $v < 3;
+
+		$this->assertSame(
+			listOf($data)->dropWhile($predicate)->toArray(),
+			sequenceOf($data)->dropWhile($predicate)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function distinct_keeps_the_first_occurrence_of_each_element(): void
+	{
+		$this->assertSame([1, 2, 3], sequenceOf([1, 2, 1, 3, 2])->distinct()->toArray());
+	}
+
+	#[Test]
+	public function distinct_matches_its_collection_counterpart(): void
+	{
+		$data = ['a', 'b', 'a', 'c'];
+
+		$this->assertSame(
+			listOf($data)->distinct()->toArray(),
+			sequenceOf($data)->distinct()->toArray(),
+		);
+	}
+
+	#[Test]
+	public function distinctBy_keeps_the_first_element_of_each_selector_value(): void
+	{
+		$this->assertSame(
+			['one', 'three'],
+			sequenceOf(['one', 'two', 'three'])->distinctBy(static fn (string $v): int => strlen($v))->toArray(),
+		);
+	}
+
+	#[Test]
+	public function distinctBy_matches_its_collection_counterpart(): void
+	{
+		$data = ['one', 'two', 'three', 'six'];
+		$selector = static fn (string $v): int => strlen($v);
+
+		$this->assertSame(
+			listOf($data)->distinctBy($selector)->toArray(),
+			sequenceOf($data)->distinctBy($selector)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function zip_pairs_elements_at_the_same_position(): void
+	{
+		$this->assertSame(
+			[[1, 'a'], [2, 'b']],
+			sequenceOf([1, 2])->zip(['a', 'b'])->toArray(),
+		);
+	}
+
+	#[Test]
+	public function zip_stops_at_the_shorter_side(): void
+	{
+		$this->assertSame([[1, 'a']], sequenceOf([1, 2, 3])->zip(['a'])->toArray());
+		$this->assertSame([[1, 'a']], sequenceOf([1])->zip(['a', 'b', 'c'])->toArray());
+		$this->assertSame([], sequenceOf([1, 2])->zip([])->toArray());
+	}
+
+	#[Test]
+	public function zip_accepts_any_iterable_on_the_other_side(): void
+	{
+		$other = (static function (): Generator {
+			yield 'a';
+			yield 'b';
+		})();
+
+		$this->assertSame([[1, 'a'], [2, 'b']], sequenceOf([1, 2, 3])->zip($other)->toArray());
+		$this->assertSame([[1, 'a']], sequenceOf([1, 2])->zip(sequenceOf(['a']))->toArray());
+	}
+
+	#[Test]
+	public function zip_matches_its_collection_counterpart(): void
+	{
+		$data = [1, 2, 3];
+		$other = ['a', 'b'];
+
+		$this->assertSame(
+			listOf($data)->zip($other)->toArray(),
+			sequenceOf($data)->zip($other)->toArray(),
+		);
+	}
+
+	#[Test]
+	public function zipWithNext_pairs_adjacent_elements(): void
+	{
+		$this->assertSame([[1, 2], [2, 3]], sequenceOf([1, 2, 3])->zipWithNext()->toArray());
+	}
+
+	#[Test]
+	public function zipWithNext_yields_nothing_below_two_elements(): void
+	{
+		$this->assertSame([], sequenceOf([1])->zipWithNext()->toArray());
+		$this->assertSame([], sequenceOf([])->zipWithNext()->toArray());
+	}
+
+	#[Test]
+	public function zipWithNext_matches_its_collection_counterpart(): void
+	{
+		$data = ['a', 'b', 'c'];
+
+		$this->assertSame(
+			listOf($data)->zipWithNext()->toArray(),
+			sequenceOf($data)->zipWithNext()->toArray(),
+		);
+	}
+
+	#[Test]
+	public function onEach_yields_the_elements_unchanged(): void
+	{
+		$seen = [];
+		$action = static function (int $v) use (&$seen): void {
+			$seen[] = $v;
+		};
+
+		$this->assertSame([1, 2, 3], sequenceOf([1, 2, 3])->onEach($action)->toArray());
+		$this->assertSame([1, 2, 3], $seen);
+	}
+
+	#[Test]
 	public function predicate_receives_positional_index(): void
 	{
 		$this->assertSame(
@@ -75,5 +386,77 @@ final class SequenceTransformTest extends TestCase
 			->toArray();
 
 		$this->assertSame(['0:a', '1:c', '2:d'], $result);
+	}
+
+	#[Test]
+	public function flatMap_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->flatMap(static fn (string $v, int $i): array => ["$i:$v"])
+			->toArray();
+
+		$this->assertSame(['0:b', '1:c'], $result);
+	}
+
+	#[Test]
+	public function mapNotNull_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->mapNotNull(static fn (string $v, int $i): string => "$i:$v")
+			->toArray();
+
+		$this->assertSame(['0:b', '1:c'], $result);
+	}
+
+	#[Test]
+	public function takeWhile_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c', 'd'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->takeWhile(static fn (string $v, int $i): bool => $i < 2)
+			->toArray();
+
+		$this->assertSame(['b', 'c'], $result);
+	}
+
+	#[Test]
+	public function dropWhile_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c', 'd'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->dropWhile(static fn (string $v, int $i): bool => $i < 2)
+			->toArray();
+
+		$this->assertSame(['d'], $result);
+	}
+
+	#[Test]
+	public function distinctBy_after_filter_receives_reindexed_positions(): void
+	{
+		$result = sequenceOf(['a', 'b', 'c', 'd', 'e'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->distinctBy(static fn (string $v, int $i): int => intdiv($i, 2))
+			->toArray();
+
+		$this->assertSame(['b', 'd'], $result);
+	}
+
+	#[Test]
+	public function onEach_after_filter_receives_reindexed_positions(): void
+	{
+		$seen = [];
+		$action = static function (string $v, int $i) use (&$seen): void {
+			$seen[] = "$i:$v";
+		};
+
+		$result = sequenceOf(['a', 'b', 'c'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->onEach($action)
+			->toArray();
+
+		$this->assertSame(['b', 'c'], $result);
+		$this->assertSame(['0:b', '1:c'], $seen);
 	}
 }

--- a/tests/Type/SequenceTransformTypeTest.php
+++ b/tests/Type/SequenceTransformTypeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Noctud\Collection\Tests\Type;
 
+use Noctud\Collection\Sequence\Sequence;
+use stdClass;
 use function Noctud\Collection\sequenceOf;
 use function PHPStan\Testing\assertType;
 
@@ -23,3 +25,45 @@ assertType(
 	'Noctud\Collection\Sequence\Sequence<float>',
 	sequenceOf([1, 2, 3])->filter(static fn (int $v): bool => $v > 1)->map(static fn (int $v): float => $v * 2.5),
 );
+
+/** @var Sequence<string> $s */
+$s = sequenceOf(['a', 'b', 'c']);
+
+// Filtering preserves the element type.
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->filterNotNull());
+assertType('Noctud\Collection\Sequence\Sequence<stdClass>', $s->filterInstanceOf(stdClass::class));
+
+/** @var Sequence<string|null> $nullable */
+$nullable = sequenceOf(['a', null]);
+assertType('Noctud\Collection\Sequence\Sequence<string>', $nullable->filterNotNull());
+
+// Mapping changes the element type.
+assertType('Noctud\Collection\Sequence\Sequence<int>', $s->mapNotNull(static fn (string $x): ?int => $x !== '' ? 1 : null));
+assertType('Noctud\Collection\Sequence\Sequence<int>', $s->flatMap(static fn (string $x): array => [(int) $x]));
+
+// flatten() keeps non-iterable elements as-is.
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->flatten());
+
+/** @var Sequence<array<int>> $arrays */
+$arrays = sequenceOf([[1, 2], [3]]);
+assertType('Noctud\Collection\Sequence\Sequence<int>', $arrays->flatten());
+
+// ...and the conditional distributes over union element types.
+/** @var Sequence<array<int>|string> $mixed */
+$mixed = sequenceOf([[1], 'a']);
+assertType('Noctud\Collection\Sequence\Sequence<int|string>', $mixed->flatten());
+
+// Slicing preserves the element type.
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->takeFirst(2));
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->dropFirst(2));
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->takeWhile(static fn (string $x): bool => $x !== ''));
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->dropWhile(static fn (string $x): bool => $x !== ''));
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->distinct());
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->distinctBy(static fn (string $x): int => (int) $x));
+
+// Pairing yields tuples, and stays a Sequence (the Collection counterparts return a list).
+assertType('Noctud\Collection\Sequence\Sequence<array{string, int}>', $s->zip([1, 2]));
+assertType('Noctud\Collection\Sequence\Sequence<array{string, string}>', $s->zipWithNext());
+
+// onEach() is a pass-through tap.
+assertType('Noctud\Collection\Sequence\Sequence<string>', $s->onEach(static fn (string $x): null => null));


### PR DESCRIPTION
Adds the lazy stage of Sequence: filterNotNull, filterInstanceOf, mapNotNull, flatMap, flatten, takeFirst, dropFirst, takeWhile, dropWhile, distinct, distinctBy, zip, zipWithNext and onEach. Each returns a new Sequence and pulls nothing until a terminal operation runs.

ZipOperation stops buffering the other side into an array and walks both sides in lockstep, reading no further than the shorter one needs. This changes Collection::zip() too, since the operation is shared. A Generator resumes where it stands, every other iterator is rewound and so restarts, and a NoRewindIterator opts out of that. Replayability is read off the same rule, so a second pass is refused only for cursors that were never rewound.

SequenceAlreadyIteratedException becomes NonReplayableSourceException, since the thing already iterated is not always the sequence. Also: takeFirst(n) now pulls exactly n elements instead of n+1, and the Sequence terminals carry @throws tags.

Refs #23