### PR TITLE
[Sequence] Add "terminal" methods: element access

### DIFF
--- a/src/CollectionLogic.php
+++ b/src/CollectionLogic.php
@@ -44,6 +44,9 @@ use NoDiscard;
  */
 trait CollectionLogic
 {
+	/** @use IterableTerminalsLogic<E> */
+	use IterableTerminalsLogic;
+
 	// --- Element Access ---
 
 	/** {@inheritDoc} */
@@ -71,50 +74,6 @@ trait CollectionLogic
 	}
 
 	/** {@inheritDoc} */
-	public function single()
-	{
-		$found = false;
-		$result = null;
-
-		foreach ($this as $v) {
-			if ($found) {
-				throw new NoSuchElementException('Collection contains more than one element');
-			}
-
-			$result = $v;
-			$found = true;
-		}
-
-		if (!$found) {
-			throw new NoSuchElementException('Collection is empty');
-		}
-
-		return $result; // @phpstan-ignore return.type
-	}
-
-	/** {@inheritDoc} */
-	public function singleOrNull(): mixed
-	{
-		try {
-			return $this->single();
-		} catch (NoSuchElementException) {
-			return null;
-		}
-	}
-
-	/** {@inheritDoc} */
-	public function find(Closure $predicate): mixed
-	{
-		foreach ($this as $i => $v) {
-			if ($predicate($v, $i)) {
-				return $v;
-			}
-		}
-
-		return null;
-	}
-
-	/** {@inheritDoc} */
 	public function findLast(Closure $predicate): mixed
 	{
 		$result = null;
@@ -126,18 +85,6 @@ trait CollectionLogic
 		}
 
 		return $result;
-	}
-
-	/** {@inheritDoc} */
-	public function expect(Closure $predicate)
-	{
-		foreach ($this as $i => $v) {
-			if ($predicate($v, $i)) {
-				return $v;
-			}
-		}
-
-		throw new NoSuchElementException('No element matching the predicate was found');
 	}
 
 	/** {@inheritDoc} */

--- a/src/Exception/NamesItsSubject.php
+++ b/src/Exception/NamesItsSubject.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Exception;
+
+use Noctud\Collection\Collection;
+use Noctud\Collection\Sequence\Sequence;
+
+/**
+ * Names what a message is about, so that a body shared by the eager and the lazy side does not
+ * have to carry two versions of its own error text: a sequence must not be told a "Collection" is
+ * empty, and that difference is the only thing that used to keep those bodies apart.
+ *
+ * @internal
+ */
+trait NamesItsSubject
+{
+	/**
+	 * @param Collection<mixed>|Sequence<mixed> $subject
+	 */
+	private static function subjectName(Collection|Sequence $subject): string
+	{
+		// The parameter type makes this exhaustive, so the default arm *is* the Collection case
+		// rather than a catch-all. Widening that union means adding an arm here.
+		return match (true) {
+			$subject instanceof Sequence => 'Sequence',
+			default => 'Collection',
+		};
+	}
+}

--- a/src/Exception/NoSuchElementException.php
+++ b/src/Exception/NoSuchElementException.php
@@ -10,7 +10,26 @@ declare(strict_types=1);
 namespace Noctud\Collection\Exception;
 
 use LogicException;
+use Noctud\Collection\Collection;
+use Noctud\Collection\Sequence\Sequence;
 
 final class NoSuchElementException extends LogicException
 {
+	use NamesItsSubject;
+
+	/**
+	 * @param Collection<mixed>|Sequence<mixed> $subject
+	 */
+	public static function emptySubject(Collection|Sequence $subject): self
+	{
+		return new self(sprintf('%s is empty', self::subjectName($subject)));
+	}
+
+	/**
+	 * @param Collection<mixed>|Sequence<mixed> $subject
+	 */
+	public static function subjectHasMoreThanOneElement(Collection|Sequence $subject): self
+	{
+		return new self(sprintf('%s contains more than one element', self::subjectName($subject)));
+	}
 }

--- a/src/IterableTerminalsLogic.php
+++ b/src/IterableTerminalsLogic.php
@@ -27,8 +27,6 @@ use Noctud\Collection\Sequence\Sequence;
  * @template E
  *
  * @internal
- *
- * @phpstan-require-implements Collection|Sequence
  */
 trait IterableTerminalsLogic
 {

--- a/src/IterableTerminalsLogic.php
+++ b/src/IterableTerminalsLogic.php
@@ -11,6 +11,7 @@ namespace Noctud\Collection;
 
 use Closure;
 use Noctud\Collection\Exception\NoSuchElementException;
+use Noctud\Collection\Sequence\Sequence;
 
 /**
  * Terminal operations implemented by walking $this and nothing else, shared by the eager
@@ -24,6 +25,10 @@ use Noctud\Collection\Exception\NoSuchElementException;
  * Collection<E> or Sequence<E> depending on who uses the trait.
  *
  * @template E
+ *
+ * @internal
+ *
+ * @phpstan-require-implements Collection|Sequence
  */
 trait IterableTerminalsLogic
 {

--- a/src/IterableTerminalsLogic.php
+++ b/src/IterableTerminalsLogic.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection;
+
+use Closure;
+use Noctud\Collection\Exception\NoSuchElementException;
+
+/**
+ * Terminal operations implemented by walking $this and nothing else, shared by the eager
+ * Collection side and the lazy Sequence side.
+ *
+ * A body belongs here only if it is identical for both, which excludes the family the eager side
+ * answers from its store in O(1) (first/last/contains/count). A message naming the subject is no
+ * longer a reason to split: the exception derives that noun from $this.
+ *
+ * Consumers declare the contract, so the PHPDoc here is {@inheritDoc}: it resolves against
+ * Collection<E> or Sequence<E> depending on who uses the trait.
+ *
+ * @template E
+ */
+trait IterableTerminalsLogic
+{
+	/** {@inheritDoc} */
+	public function single()
+	{
+		$found = false;
+		$result = null;
+
+		foreach ($this as $v) {
+			if ($found) {
+				throw NoSuchElementException::subjectHasMoreThanOneElement($this);
+			}
+
+			$result = $v;
+			$found = true;
+		}
+
+		if (!$found) {
+			throw NoSuchElementException::emptySubject($this);
+		}
+
+		return $result; // @phpstan-ignore return.type
+	}
+
+	/** {@inheritDoc} */
+	public function singleOrNull(): mixed
+	{
+		try {
+			return $this->single();
+		} catch (NoSuchElementException) {
+			return null;
+		}
+	}
+
+	/** {@inheritDoc} */
+	public function find(Closure $predicate): mixed
+	{
+		foreach ($this as $i => $v) {
+			if ($predicate($v, $i)) {
+				return $v;
+			}
+		}
+
+		return null;
+	}
+
+	/** {@inheritDoc} */
+	public function expect(Closure $predicate)
+	{
+		foreach ($this as $i => $v) {
+			if ($predicate($v, $i)) {
+				return $v;
+			}
+		}
+
+		throw new NoSuchElementException('No element matching the predicate was found');
+	}
+}

--- a/src/IterableTerminalsLogic.php
+++ b/src/IterableTerminalsLogic.php
@@ -11,7 +11,6 @@ namespace Noctud\Collection;
 
 use Closure;
 use Noctud\Collection\Exception\NoSuchElementException;
-use Noctud\Collection\Sequence\Sequence;
 
 /**
  * Terminal operations implemented by walking $this and nothing else, shared by the eager

--- a/src/IterableTerminalsLogic.php
+++ b/src/IterableTerminalsLogic.php
@@ -49,14 +49,27 @@ trait IterableTerminalsLogic
 		return $result; // @phpstan-ignore return.type
 	}
 
-	/** {@inheritDoc} */
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Not a try-catch around single(): iterating $this runs user closures on the lazy side, and a
+	 * NoSuchElementException raised inside one is a real error, not an answer to this question.
+	 */
 	public function singleOrNull(): mixed
 	{
-		try {
-			return $this->single();
-		} catch (NoSuchElementException) {
-			return null;
+		$found = false;
+		$result = null;
+
+		foreach ($this as $v) {
+			if ($found) {
+				return null;
+			}
+
+			$result = $v;
+			$found = true;
 		}
+
+		return $result;
 	}
 
 	/** {@inheritDoc} */

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -295,7 +295,7 @@ interface Sequence extends IteratorAggregate
 	 *
 	 * @param non-negative-int $index
 	 * @return E
-	 * @throws IndexOutOfBoundsException If the sequence holds fewer elements than that
+	 * @throws IndexOutOfBoundsException If the sequence holds fewer elements than that or if the index is a negative int
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
@@ -307,6 +307,7 @@ interface Sequence extends IteratorAggregate
 	 *
 	 * @param non-negative-int $index
 	 * @return E|null
+	 * @throws IndexOutOfBoundsException If the index is a negative int
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -230,7 +230,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function first();
 
 	/**
@@ -240,7 +239,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function firstOrNull(): mixed;
 
 	/**
@@ -253,7 +251,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function last();
 
 	/**
@@ -263,7 +260,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function lastOrNull(): mixed;
 
 	/**
@@ -275,7 +271,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function single();
 
 	/**
@@ -285,7 +280,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function singleOrNull(): mixed;
 
 	/**
@@ -299,7 +293,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function elementAt(int $index);
 
 	/**
@@ -311,7 +304,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function elementAtOrNull(int $index): mixed;
 
 	/**
@@ -323,7 +315,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function find(Closure $predicate): mixed;
 
 	/**
@@ -336,7 +327,6 @@ interface Sequence extends IteratorAggregate
 	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
 	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
 	 */
-	#[NoDiscard]
 	public function expect(Closure $predicate);
 
 	// --- Conversion ---

--- a/src/Sequence/Sequence.php
+++ b/src/Sequence/Sequence.php
@@ -11,8 +11,10 @@ namespace Noctud\Collection\Sequence;
 
 use Closure;
 use IteratorAggregate;
+use Noctud\Collection\Exception\IndexOutOfBoundsException;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
 use Noctud\Collection\Exception\NonReplayableSourceException;
+use Noctud\Collection\Exception\NoSuchElementException;
 use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Set\ImmutableSet;
 use NoDiscard;
@@ -217,6 +219,124 @@ interface Sequence extends IteratorAggregate
 	 */
 	#[NoDiscard]
 	public function onEach(Closure $action): Sequence;
+
+	// --- Element Access ---
+
+	/**
+	 * Returns the first element, consuming one pass. Pulls exactly one element.
+	 *
+	 * @return E
+	 * @throws NoSuchElementException If the sequence is empty
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function first();
+
+	/**
+	 * Returns the first element, or null if the sequence is empty. Pulls exactly one element.
+	 *
+	 * @return E|null
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function firstOrNull(): mixed;
+
+	/**
+	 * Returns the last element, consuming one pass.
+	 * Unlike its Collection counterpart this drains the whole sequence - the last element is
+	 * only knowable at the end.
+	 *
+	 * @return E
+	 * @throws NoSuchElementException If the sequence is empty
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function last();
+
+	/**
+	 * Returns the last element, or null if the sequence is empty. Drains the sequence.
+	 *
+	 * @return E|null
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function lastOrNull(): mixed;
+
+	/**
+	 * Returns the single element, consuming one pass. Pulls at most two elements: a second one
+	 * existing is already an error.
+	 *
+	 * @return E
+	 * @throws NoSuchElementException If the sequence is empty or holds more than one element
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function single();
+
+	/**
+	 * Returns the single element, or null if the sequence is empty or holds more than one.
+	 *
+	 * @return E|null
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function singleOrNull(): mixed;
+
+	/**
+	 * Returns the element at the given position, consuming one pass.
+	 * Pulls up to that position and no further; there is no length to check the index against
+	 * beforehand, so an index past the end is only known once the sequence runs out.
+	 *
+	 * @param non-negative-int $index
+	 * @return E
+	 * @throws IndexOutOfBoundsException If the sequence holds fewer elements than that
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function elementAt(int $index);
+
+	/**
+	 * Returns the element at the given position, or null if the sequence is shorter than that.
+	 *
+	 * @param non-negative-int $index
+	 * @return E|null
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function elementAtOrNull(int $index): mixed;
+
+	/**
+	 * Returns the first element matching the predicate, or null if none does.
+	 * Stops pulling at the first match.
+	 *
+	 * @param Closure(E, int):bool $predicate
+	 * @return E|null
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function find(Closure $predicate): mixed;
+
+	/**
+	 * Returns the first element matching the predicate, throwing if none does.
+	 * Stops pulling at the first match.
+	 *
+	 * @param Closure(E, int):bool $predicate
+	 * @return E
+	 * @throws NoSuchElementException If no element matches the predicate
+	 * @throws NonReplayableSourceException If a non-replayable source has already been consumed
+	 * @throws InvalidSequenceSourceException If a Closure source returns a non-iterable
+	 */
+	#[NoDiscard]
+	public function expect(Closure $predicate);
 
 	// --- Conversion ---
 

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -12,8 +12,11 @@ namespace Noctud\Collection\Sequence;
 use Closure;
 use Generator;
 use IteratorAggregate;
+use Noctud\Collection\Exception\IndexOutOfBoundsException;
 use Noctud\Collection\Exception\InvalidSequenceSourceException;
 use Noctud\Collection\Exception\NonReplayableSourceException;
+use Noctud\Collection\Exception\NoSuchElementException;
+use Noctud\Collection\IterableTerminalsLogic;
 use Noctud\Collection\List\ImmutableList;
 use Noctud\Collection\Operation\DistinctOperation;
 use Noctud\Collection\Operation\DropOperation;
@@ -37,6 +40,9 @@ use function Noctud\Collection\setOf;
  */
 trait SequenceLogic
 {
+	/** @use IterableTerminalsLogic<E> */
+	use IterableTerminalsLogic;
+
 	/** @var iterable<E>|Closure():iterable<E> */
 	private iterable|Closure $source;
 
@@ -211,6 +217,103 @@ trait SequenceLogic
 
 			return $v;
 		}));
+	}
+
+	// --- Element Access ---
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * The eager side answers this from its store; a sequence has to pull, and returning inside
+	 * the foreach is what keeps it to a single element.
+	 */
+	#[NoDiscard]
+	public function first()
+	{
+		foreach ($this as $v) {
+			return $v;
+		}
+
+		throw NoSuchElementException::emptySubject($this);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Kotlin's index accessor rather than a List's: there is no length to bounds-check against, so
+	 * the index is only known to be past the end once the source runs out.
+	 */
+	#[NoDiscard]
+	public function elementAt(int $index)
+	{
+		foreach ($this as $i => $v) {
+			if ($i === $index) {
+				return $v;
+			}
+		}
+
+		throw new IndexOutOfBoundsException('Index out of bounds: ' . $index);
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function elementAtOrNull(int $index): mixed
+	{
+		foreach ($this as $i => $v) {
+			if ($i === $index) {
+				return $v;
+			}
+		}
+
+		return null;
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function firstOrNull(): mixed
+	{
+		foreach ($this as $v) {
+			return $v;
+		}
+
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * No array_key_last to lean on here: the last element is only knowable once the source is
+	 * exhausted, so this drains it.
+	 */
+	#[NoDiscard]
+	public function last()
+	{
+		$found = false;
+		$result = null;
+
+		foreach ($this as $v) {
+			$result = $v;
+			$found = true;
+		}
+
+		if (!$found) {
+			throw NoSuchElementException::emptySubject($this);
+		}
+
+		return $result; // @phpstan-ignore return.type
+	}
+
+	/** {@inheritDoc} */
+	#[NoDiscard]
+	public function lastOrNull(): mixed
+	{
+		$result = null;
+
+		foreach ($this as $v) {
+			$result = $v;
+		}
+
+		return $result;
 	}
 
 	// --- Conversion ---

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -227,7 +227,6 @@ trait SequenceLogic
 	 * The eager side answers this from its store; a sequence has to pull, and returning inside
 	 * the foreach is what keeps it to a single element.
 	 */
-	#[NoDiscard]
 	public function first()
 	{
 		foreach ($this as $v) {
@@ -244,7 +243,6 @@ trait SequenceLogic
 	 * there is no length to bounds-check against, so an index past the end is only known once
 	 * the source runs out.
 	 */
-	#[NoDiscard]
 	public function elementAt(int $index)
 	{
 		// @phpstan-ignore smaller.alwaysFalse (defensive guard: the phpdoc type does not bind untyped callers)
@@ -262,7 +260,6 @@ trait SequenceLogic
 	}
 
 	/** {@inheritDoc} */
-	#[NoDiscard]
 	public function elementAtOrNull(int $index): mixed
 	{
 		// @phpstan-ignore smaller.alwaysFalse (defensive guard: the phpdoc type does not bind untyped callers)
@@ -280,7 +277,6 @@ trait SequenceLogic
 	}
 
 	/** {@inheritDoc} */
-	#[NoDiscard]
 	public function firstOrNull(): mixed
 	{
 		foreach ($this as $v) {
@@ -296,7 +292,6 @@ trait SequenceLogic
 	 * No array_key_last to lean on here: the last element is only knowable once the source is
 	 * exhausted, so this drains it.
 	 */
-	#[NoDiscard]
 	public function last()
 	{
 		$found = false;
@@ -315,7 +310,6 @@ trait SequenceLogic
 	}
 
 	/** {@inheritDoc} */
-	#[NoDiscard]
 	public function lastOrNull(): mixed
 	{
 		$result = null;

--- a/src/Sequence/SequenceLogic.php
+++ b/src/Sequence/SequenceLogic.php
@@ -240,12 +240,18 @@ trait SequenceLogic
 	/**
 	 * {@inheritDoc}
 	 *
-	 * Kotlin's index accessor rather than a List's: there is no length to bounds-check against, so
-	 * the index is only known to be past the end once the source runs out.
+	 * Kotlin's index accessor rather than a List's: a negative index is rejected up front, but
+	 * there is no length to bounds-check against, so an index past the end is only known once
+	 * the source runs out.
 	 */
 	#[NoDiscard]
 	public function elementAt(int $index)
 	{
+		// @phpstan-ignore smaller.alwaysFalse (defensive guard: the phpdoc type does not bind untyped callers)
+		if ($index < 0) {
+			throw new IndexOutOfBoundsException('Cannot use a negative index.');
+		}
+
 		foreach ($this as $i => $v) {
 			if ($i === $index) {
 				return $v;
@@ -259,6 +265,11 @@ trait SequenceLogic
 	#[NoDiscard]
 	public function elementAtOrNull(int $index): mixed
 	{
+		// @phpstan-ignore smaller.alwaysFalse (defensive guard: the phpdoc type does not bind untyped callers)
+		if ($index < 0) {
+			throw new IndexOutOfBoundsException('Cannot use a negative index.');
+		}
+
 		foreach ($this as $i => $v) {
 			if ($i === $index) {
 				return $v;

--- a/tests/Collection/CollectionAggregate.php
+++ b/tests/Collection/CollectionAggregate.php
@@ -68,6 +68,7 @@ trait CollectionAggregate
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(UnsupportedOperationException::class);
+		$this->expectExceptionMessageIsOrContains('Cannot compute average of empty collection');
 		$collection->avg();
 	}
 
@@ -126,6 +127,7 @@ trait CollectionAggregate
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection is empty');
 		$collection->max();
 	}
 
@@ -192,6 +194,7 @@ trait CollectionAggregate
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection is empty');
 		$collection->min();
 	}
 
@@ -361,6 +364,7 @@ trait CollectionAggregate
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection is empty');
 		$collection->minOf(fn ($element) => $element);
 	}
 
@@ -406,6 +410,7 @@ trait CollectionAggregate
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection is empty');
 		$collection->maxOf(fn ($element) => $element);
 	}
 

--- a/tests/Collection/CollectionSingle.php
+++ b/tests/Collection/CollectionSingle.php
@@ -27,6 +27,7 @@ trait CollectionSingle
 		$collection = $this->collectionOf([]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection is empty');
 		$collection->single();
 	}
 
@@ -36,6 +37,7 @@ trait CollectionSingle
 		$collection = $this->collectionOf([1, 2]);
 
 		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Collection contains more than one element');
 		$collection->single();
 	}
 

--- a/tests/Sequence/SequenceTerminalTest.php
+++ b/tests/Sequence/SequenceTerminalTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Sequence;
+
+use Generator;
+use Noctud\Collection\Exception\IndexOutOfBoundsException;
+use Noctud\Collection\Exception\NonReplayableSourceException;
+use Noctud\Collection\Exception\NoSuchElementException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function Noctud\Collection\listOf;
+use function Noctud\Collection\sequenceOf;
+
+final class SequenceTerminalTest extends TestCase
+{
+	#[Test]
+	public function first_returns_the_first_element(): void
+	{
+		$this->assertSame(1, sequenceOf([1, 2, 3])->first());
+	}
+
+	#[Test]
+	public function first_throws_on_an_empty_sequence(): void
+	{
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Sequence is empty');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([])->first();
+	}
+
+	#[Test]
+	public function firstOrNull_returns_null_on_an_empty_sequence(): void
+	{
+		$this->assertSame(1, sequenceOf([1, 2])->firstOrNull());
+
+		// Emptied by a filter rather than empty at the source: the realistic way a pipeline
+		// ends up with nothing, and it keeps a real element type instead of never.
+		$this->assertNull(sequenceOf([1, 2])->filter(static fn (int $v): bool => $v > 9)->firstOrNull());
+	}
+
+	#[Test]
+	public function last_returns_the_last_element(): void
+	{
+		$this->assertSame(3, sequenceOf([1, 2, 3])->last());
+	}
+
+	#[Test]
+	public function last_throws_on_an_empty_sequence(): void
+	{
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Sequence is empty');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([])->last();
+	}
+
+	#[Test]
+	public function lastOrNull_returns_null_on_an_empty_sequence(): void
+	{
+		$this->assertSame(3, sequenceOf([1, 2, 3])->lastOrNull());
+		$this->assertNull(sequenceOf([1, 2])->filter(static fn (int $v): bool => $v > 9)->lastOrNull());
+	}
+
+	#[Test]
+	public function lastOrNull_returns_a_trailing_null_element(): void
+	{
+		// A sequence ending on null is indistinguishable from an empty one through this
+		// terminal - the same ambiguity Collection::lastOrNull() has, kept deliberately.
+		$this->assertNull(sequenceOf([1, null])->lastOrNull());
+	}
+
+	#[Test]
+	public function single_returns_the_only_element(): void
+	{
+		$this->assertSame(1, sequenceOf([1])->single());
+	}
+
+	#[Test]
+	public function single_throws_on_an_empty_sequence(): void
+	{
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Sequence is empty');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([])->single();
+	}
+
+	#[Test]
+	public function single_throws_on_more_than_one_element(): void
+	{
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Sequence contains more than one element');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([1, 2])->single();
+	}
+
+	#[Test]
+	public function singleOrNull_returns_null_when_empty_or_ambiguous(): void
+	{
+		$this->assertSame(1, sequenceOf([1])->singleOrNull());
+		$this->assertNull(sequenceOf([1, 2])->filter(static fn (int $v): bool => $v > 9)->singleOrNull());
+		$this->assertNull(sequenceOf([1, 2])->singleOrNull());
+	}
+
+	#[Test]
+	public function elementAt_returns_the_element_at_that_position(): void
+	{
+		$this->assertSame('b', sequenceOf(['a', 'b', 'c'])->elementAt(1));
+		$this->assertSame('a', sequenceOf(['a', 'b', 'c'])->elementAt(0));
+	}
+
+	#[Test]
+	public function elementAt_throws_past_the_end(): void
+	{
+		$this->expectException(IndexOutOfBoundsException::class);
+		$this->expectExceptionMessageIsOrContains('Index out of bounds: 3');
+
+		$_ = sequenceOf(['a', 'b', 'c'])->elementAt(3); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+	}
+
+	#[Test]
+	public function elementAtOrNull_returns_null_past_the_end(): void
+	{
+		$this->assertSame('b', sequenceOf(['a', 'b', 'c'])->elementAtOrNull(1));
+		$this->assertNull(sequenceOf(['a', 'b', 'c'])->elementAtOrNull(3));
+	}
+
+	#[Test]
+	public function elementAt_counts_the_positions_of_its_own_stage(): void
+	{
+		// Indexes are positional per stage, so a filter renumbers what elementAt() counts.
+		$sequence = sequenceOf([1, 2, 3, 4])->filter(static fn (int $v): bool => $v % 2 === 0);
+
+		$this->assertSame(4, $sequence->elementAt(1));
+	}
+
+	#[Test]
+	public function elementAt_stops_pulling_at_that_position(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3, 4] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		$this->assertSame(2, $sequence->elementAt(1));
+		$this->assertSame([1, 2], $pulled);
+	}
+
+	#[Test]
+	public function find_returns_the_first_match_or_null(): void
+	{
+		$this->assertSame(2, sequenceOf([1, 2, 3, 4])->find(static fn (int $v): bool => $v % 2 === 0));
+		$this->assertNull(sequenceOf([1, 3])->find(static fn (int $v): bool => $v % 2 === 0));
+	}
+
+	#[Test]
+	public function find_receives_the_positional_index(): void
+	{
+		$seen = [];
+		$found = sequenceOf(['a', 'b', 'c'])
+			->filter(static fn (string $v): bool => $v !== 'a')
+			->find(static function (string $v, int $i) use (&$seen): bool {
+				$seen[] = "$i:$v";
+
+				return $v === 'c';
+			});
+
+		// Indexes are the positions of this stage, not of the source: the filter reindexed.
+		$this->assertSame('c', $found);
+		$this->assertSame(['0:b', '1:c'], $seen);
+	}
+
+	#[Test]
+	public function expect_returns_the_first_match(): void
+	{
+		$this->assertSame(2, sequenceOf([1, 2, 3])->expect(static fn (int $v): bool => $v % 2 === 0));
+	}
+
+	#[Test]
+	public function expect_throws_when_nothing_matches(): void
+	{
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('No element matching the predicate was found');
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = sequenceOf([1, 3])->expect(static fn (int $v): bool => $v % 2 === 0);
+	}
+
+	#[Test]
+	public function element_access_matches_its_collection_counterpart(): void
+	{
+		$data = [3, 1, 4, 1, 5];
+		$even = static fn (int $v): bool => $v % 2 === 0;
+
+		$this->assertSame(listOf($data)->first(), sequenceOf($data)->first());
+		$this->assertSame(listOf($data)->firstOrNull(), sequenceOf($data)->firstOrNull());
+		$this->assertSame(listOf($data)->last(), sequenceOf($data)->last());
+		$this->assertSame(listOf($data)->lastOrNull(), sequenceOf($data)->lastOrNull());
+		$this->assertSame(listOf($data)->find($even), sequenceOf($data)->find($even));
+		$this->assertSame(listOf($data)->expect($even), sequenceOf($data)->expect($even));
+		$this->assertSame(listOf([7])->single(), sequenceOf([7])->single());
+		$this->assertSame(listOf($data)->singleOrNull(), sequenceOf($data)->singleOrNull());
+	}
+
+	#[Test]
+	public function first_pulls_exactly_one_element(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		$this->assertSame(1, $sequence->first());
+		$this->assertSame([1], $pulled);
+	}
+
+	#[Test]
+	public function single_pulls_at_most_two_elements(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3, 4] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		try {
+			// A second element existing is already the answer: nothing beyond it is pulled.
+            // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+			$_ = $sequence->single();
+		} catch (NoSuchElementException) {
+			// expected
+		}
+
+		$this->assertSame([1, 2], $pulled);
+	}
+
+	#[Test]
+	public function find_stops_pulling_at_the_first_match(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3, 4] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		$this->assertSame(2, $sequence->find(static fn (int $v): bool => $v % 2 === 0));
+		$this->assertSame([1, 2], $pulled);
+	}
+
+	#[Test]
+	public function last_drains_the_source(): void
+	{
+		$pulled = [];
+		$sequence = sequenceOf(static function () use (&$pulled): Generator {
+			foreach ([1, 2, 3] as $value) {
+				$pulled[] = $value;
+
+				yield $value;
+			}
+		});
+
+		// No array_key_last to lean on: the last element is only knowable at the end.
+		$this->assertSame(3, $sequence->last());
+		$this->assertSame([1, 2, 3], $pulled);
+	}
+
+	#[Test]
+	public function a_terminal_consumes_a_pass_of_a_one_shot_source(): void
+	{
+		$sequence = sequenceOf((static function (): Generator {
+			yield 1;
+			yield 2;
+		})());
+
+		$this->assertSame(1, $sequence->first());
+
+		// Even a partial pass counts as consumed - there is no resuming from the middle.
+		$this->expectException(NonReplayableSourceException::class);
+
+        // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$_ = $sequence->first();
+	}
+
+	#[Test]
+	public function element_access_replays_over_a_replayable_source(): void
+	{
+		$sequence = sequenceOf([1, 2, 3]);
+
+		$this->assertSame(1, $sequence->first());
+		$this->assertSame(3, $sequence->last());
+		$this->assertSame(1, $sequence->first());
+	}
+}

--- a/tests/Sequence/SequenceTerminalTest.php
+++ b/tests/Sequence/SequenceTerminalTest.php
@@ -128,10 +128,30 @@ final class SequenceTerminalTest extends TestCase
 	}
 
 	#[Test]
+	public function elementAt_throws_on_a_negative_index(): void
+	{
+		$this->expectException(IndexOutOfBoundsException::class);
+		$this->expectExceptionMessageIsOrContains('Cannot use a negative index');
+
+		// @phpstan-ignore argument.type
+		$_ = sequenceOf(['a', 'b', 'c'])->elementAt(-1); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+	}
+
+	#[Test]
 	public function elementAtOrNull_returns_null_past_the_end(): void
 	{
 		$this->assertSame('b', sequenceOf(['a', 'b', 'c'])->elementAtOrNull(1));
 		$this->assertNull(sequenceOf(['a', 'b', 'c'])->elementAtOrNull(3));
+	}
+
+	#[Test]
+	public function elementAtOrNull_throws_on_a_negative_index(): void
+	{
+		$this->expectException(IndexOutOfBoundsException::class);
+		$this->expectExceptionMessageIsOrContains('Cannot use a negative index');
+
+		// @phpstan-ignore argument.type
+		$_ = sequenceOf(['a', 'b', 'c'])->elementAtOrNull(-1); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 	}
 
 	#[Test]

--- a/tests/Sequence/SequenceTerminalTest.php
+++ b/tests/Sequence/SequenceTerminalTest.php
@@ -112,6 +112,20 @@ final class SequenceTerminalTest extends TestCase
 	}
 
 	#[Test]
+	public function singleOrNull_propagates_a_NoSuchElementException_thrown_by_a_stage(): void
+	{
+		// A mapper failing over some other subject is a real error, not "no single element" here.
+		$sequence = sequenceOf([1])->map(static function (): int {
+			throw new NoSuchElementException('Raised inside the pipeline');
+		});
+
+		$this->expectException(NoSuchElementException::class);
+		$this->expectExceptionMessageIsOrContains('Raised inside the pipeline');
+
+		$_ = $sequence->singleOrNull(); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+	}
+
+	#[Test]
 	public function elementAt_returns_the_element_at_that_position(): void
 	{
 		$this->assertSame('b', sequenceOf(['a', 'b', 'c'])->elementAt(1));

--- a/tests/Type/SequenceTerminalTypeTest.php
+++ b/tests/Type/SequenceTerminalTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Noctud Collection.
+ * Copyright (c) Noctud.dev
+ */
+
+declare(strict_types=1);
+
+namespace Noctud\Collection\Tests\Type;
+
+use Noctud\Collection\Sequence\Sequence;
+use function Noctud\Collection\sequenceOf;
+use function PHPStan\Testing\assertType;
+
+/** @var Sequence<string> $s */
+$s = sequenceOf(['a', 'b', 'c']);
+
+// The throwing element accessors return the element type itself.
+assertType('string', $s->first());
+assertType('string', $s->last());
+assertType('string', $s->single());
+assertType('string', $s->expect(static fn (string $v): bool => $v !== 'a'));
+
+// Their OrNull counterparts widen it with null, find() included.
+assertType('string|null', $s->firstOrNull());
+assertType('string|null', $s->lastOrNull());
+assertType('string|null', $s->singleOrNull());
+assertType('string|null', $s->find(static fn (string $v): bool => $v !== 'a'));
+
+// Index access carries the element type, and widens with null in the OrNull variant.
+assertType('string', $s->elementAt(1));
+assertType('string|null', $s->elementAtOrNull(1));
+
+// The element type follows the pipeline rather than the source.
+assertType('float', sequenceOf([1, 2, 3])->map(static fn (int $v): float => $v * 2.5)->first());
+assertType('int|null', sequenceOf([1, 2, 3])->filter(static fn (int $v): bool => $v > 1)->firstOrNull());
+
+/** @var Sequence<string|null> $nullable */
+$nullable = sequenceOf(['a', null]);
+
+// filterNotNull() narrows what the accessors can hand back.
+assertType('string|null', $nullable->firstOrNull());
+assertType('string', $nullable->filterNotNull()->first());


### PR DESCRIPTION
Related to #23. 

First of four PRs bringing the terminal vocabulary to `Sequence` — element access here, then querying, aggregation, and `forEach`/`toMap`.

Until now a sequence could only be *ended* by `toList()`/`toSet()`/`toArray()`, so `sequenceOf($rows)->filter(…)->first()` did not exist: you had to materialize a list first, which defeats the point of the type. This adds `first`/`firstOrNull`, `last`/`lastOrNull`, `single`/`singleOrNull`, `elementAt`/`elementAtOrNull`, `find` and `expect`.

## Terminals are shared, not duplicated

The original plan was to copy the `foreach ($this …)` bodies from `CollectionLogic` into `SequenceLogic` and keep the footprint on existing files near zero. With ~25 shareable bodies in total across the four PRs, that would have meant two copies drifting apart, so this goes the other way: bodies identical on both sides live in a new `IterableTerminalsLogic`, used by `CollectionLogic` and `SequenceLogic` alike.

The open risk was PHPStan. The trait carries `@template E`, is consumed through `/** @use IterableTerminalsLogic<E> */`, and its PHPDoc is reduced to `{@inheritDoc}` so that each method resolves against whichever interface the consumer implements — `Collection<E>` or `Sequence<E>`. That turns out to be clean at level 9 with no new ignores, which is what made sharing viable.

## The exception derives the subject's name

A message naming its own subject used to be a second reason to duplicate: a sequence must not be told a *"Collection"* is empty. Rather than keep two copies of `single()` for two nouns, `NoSuchElementException` now derives the noun from the subject it is handed:

```php
throw NoSuchElementException::emptySubject($this);
```

```
listOf([])->single()           Collection is empty
setOf([])->single()            Collection is empty
mapOf([])->values->single()    Collection is empty
sequenceOf([])->single()       Sequence is empty
```

One body, the right noun. The `match` lives in an `@internal NamesItsSubject` trait shared by the exception classes; its parameter type `Collection|Sequence` makes it exhaustive, so the `default` arm *is* the Collection case rather than a catch-all.

This also unblocks the aggregation PR: `min`, `max`, `minOf`, `maxOf` and `avg` are duplicated today for that reason and that reason only.

**`CollectionSingle` and `CollectionAggregate` now assert the eager messages.** They asserted only the exception class before, so nothing would have caught the shared factory silently changing `'Collection is empty'` — without those seven assertions, a green suite would not have proven the refactor preserved the eager side.

## What deliberately stays per side

`first`/`last` are **not** shared, and that is structural rather than incidental: the eager side answers them from its store in O(1) (`array_key_first`/`array_key_last`), while a sequence has to pull. So `first()` returns inside the `foreach` to keep it to exactly one element, and `last()` drains — the last element is only knowable once the source runs out. Same reasoning will apply to `contains` and `count` in the querying PR.

## `elementAt` / `elementAtOrNull`

These are **new vocabulary**, and on `Sequence` only. The library's index accessor is `ListInterface::get()`, which is O(1) random access a sequence cannot offer. Kotlin draws the same line between `List.get()` and `Sequence.elementAt()`, and the distinct name is what carries the O(n) cost to the reader — `get(int)` on a sequence would suggest a direct access it cannot do.

They are also deliberately *not* in the shared trait: `Collection` does not declare them, so putting them there would add an undeclared public method to every set and map view. Happy to expose them on `Collection` too if that is preferred, but that is an API addition rather than sharing.

Note this makes three places where `Sequence` diverges from `Collection`: `onEach` (already merged, its `Collection` counterpart being a separate follow-up), plus these two.

## `#[NoDiscard]` follows the `Collection` rule

Terminals carried the attribute everywhere in the first version, on the argument that discarding one burns the only pass a sequence may have. Dropped after review: the rule kept everywhere on the eager side is that `#[NoDiscard]` marks what hands back a new container while leaving the subject untouched — transformation, ordering, conversion — and an element access returns an element, not a container. So `first()`, `single()`, `elementAt()`, `find()` and friends carry no attribute here either, while `filter()`/`map()`/`toList()` keep theirs.

This also removes an incoherence the attribute already had: `Sequence` declared it on `single()` while the body inherited from the shared `IterableTerminalsLogic` carries none. Whether to widen the rule for `Collection` and `Sequence` together is tracked in #30.

## Other details worth flagging

- Empty-sequence behaviour is pinned per terminal, including that a sequence ending on `null` is indistinguishable from an empty one through `lastOrNull()` — the same ambiguity `Collection::lastOrNull()` has, kept on purpose.
- Laziness is asserted, not assumed: `first()` pulls exactly one element, `single()` at most two, `find()` stops at the match, `elementAt()` stops at the position, `last()` drains.
- Every terminal consumes exactly one pass, so a second call on a one-shot source throws — a partial pass counts as consumed.
- Index arguments passed to callbacks are the positions of *that stage*, not of the source, which the `find`/`elementAt` tests pin after a `filter` reindexes.

## Verification

`composer qa` green — PHPStan level 9 over 246 files with no new ignores, phpcs clean, 6338 tests. `php bin/generate-all.php` leaves the generated narrowing files untouched.

